### PR TITLE
Make sets callable with regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ For brew builds you can provide either the NVR (e.g. leapp-0.16.0-1.el9) or the 
 Multiple `--plan` options can be specified and will be dispatched in separate jobs.
 `--tier` options allow you to run predefined test tiers from your configuration.
 `--set` options allow you to use pre-configured test sets (see Test Sets section below).
+`--set-regex` allows selecting multiple test sets by Python regular expression (expanded to concrete set names before validation).
 **Plan Override Behavior:** When using `--plan` with `--tier` or `--set`, the CLI plans override any `plans` defined in configuration or test sets.
 When using `--planfilter` or `--test` to specify singular test it is disallowed to request multiple `--plan` options in one command.<br>
 Use `--wait` if waiting for a successful response from the endpoint is required.
@@ -158,6 +159,12 @@ enge test --copr pr123 --tier tier0 --tier tier1
 
 # Test using a predefined test set
 enge test --set pre-release-smoke
+
+# Select multiple sets by regex (names under [tests.set.<name>])
+enge test --set-regex '^pre-release-.*'
+
+# Combine exact and regex selection (deduplicated, order preserved)
+enge test --set pre-release-smoke --set-regex 'regression-[0-9]+'
 
 # Test with custom tags for archiving
 enge test --copr pr123 --tier tier0 --set-tag regression --set-tag pr123
@@ -225,10 +232,26 @@ When a test set defines multiple tiers and architectures, a separate payload is 
 **Usage:**
 - Use `--set <set-name>` to run a predefined test set
 - Multiple sets can be specified: `--set set1 --set set2`
+- Use `--set-regex <regex>` to select sets by name using Python regular expressions; can be specified multiple times
 - CLI arguments override test set configurations when provided
 - Test sets can define plans, artifacts, environment variables, and test selection criteria
 - When using `--plan` with `--set`, CLI plans completely override any plans defined in the test set
 - The `--source` argument is not required when using `--set` (it's defined in the set configuration)
+
+`--set-regex` behavior:
+- Matches against names defined under `[tests.set.<name>]` in configuration
+- Each regex expands to all matching set names; expansions are logged for visibility
+- Combined with `--set`, results are merged, order-preserved, and de-duplicated
+- Invalid patterns or patterns that match nothing cause a clear error listing available sets
+
+Examples:
+```bash
+# Run all regression sets like regression-1, regression-2, ...
+enge test --set-regex 'regression-[0-9]+$'
+
+# Combine with exact set
+enge test --set smoke --set-regex 'regression-.*'
+```
 
 **Priority Order:**
 - CLI arguments > Test Set configuration > Main configuration

--- a/src/enge/utils/arg_parser.py
+++ b/src/enge/utils/arg_parser.py
@@ -119,6 +119,17 @@ def get_arguments(args: Optional[list] = None) -> argparse.Namespace:
     )
 
     test.add_argument(
+        "--set-regex",
+        action="append",
+        metavar="REGEX",
+        help=(
+            "Regular expression to select test sets by name. "
+            "Matches against names under [tests.set.<name>] (Python regex). "
+            "Can be specified multiple times; expands to concrete set names before validation."
+        ),
+    )
+
+    test.add_argument(
         "--plan",
         action="append",
         help=(

--- a/src/enge/utils/opt_manager.py
+++ b/src/enge/utils/opt_manager.py
@@ -1,5 +1,6 @@
 # #!/usr/bin/env python3
 import logging
+import re
 import os
 import sys
 from typing import Dict, List, Any, Optional, Callable
@@ -54,6 +55,9 @@ class ParsedOpts:
         )
         self.config = load_config(paths=config_paths)
 
+        # Expand --set-regex into concrete set names before any validation
+        self._expand_set_regex_arguments()
+
         # Centralized validation - this replaces all scattered validation
         self._validate_all_options()
 
@@ -98,6 +102,87 @@ class ParsedOpts:
         self._register_runtime_validation_hooks()
 
         logger.debug("Centralized validation completed successfully")
+
+    def _expand_set_regex_arguments(self) -> None:
+        """Expand --set-regex patterns into concrete set names.
+
+        This runs after configuration load and before validation so that
+        existing validation and dispatch logic operates on resolved set names.
+        """
+        try:
+            action = getattr(self.cli_args, "action", None)
+            if action != "test":
+                return
+            patterns = getattr(self.cli_args, "set_regex", None)
+            if not patterns:
+                return
+
+            tests_section = (
+                self.config.get("tests", {}) if hasattr(self.config, "get") else {}
+            )
+            available_sets_dict = (
+                tests_section.get("set", {}) if isinstance(tests_section, dict) else {}
+            )
+            available_sets = (
+                list(available_sets_dict.keys())
+                if isinstance(available_sets_dict, dict)
+                else []
+            )
+
+            if not available_sets:
+                raise ValidationError(
+                    "No test sets configured; --set-regex cannot be used."
+                )
+
+            # Start with any explicitly provided --set values
+            resolved_sets = []
+            explicit_sets = getattr(self.cli_args, "set", None) or []
+            for name in explicit_sets:
+                if name not in resolved_sets:
+                    resolved_sets.append(name)
+
+            errors: List[str] = []
+
+            for pattern in patterns:
+                try:
+                    regex = re.compile(pattern)
+                except re.error as e:
+                    errors.append(f"Invalid --set-regex pattern '{pattern}': {e}")
+                    continue
+
+                matched = [name for name in available_sets if regex.search(name)]
+                if not matched:
+                    errors.append(
+                        f"--set-regex pattern '{pattern}' matched no sets. Available: {available_sets}"
+                    )
+                    continue
+
+                for name in matched:
+                    if name not in resolved_sets:
+                        resolved_sets.append(name)
+
+                logger.info(
+                    "--set-regex '%s' expanded to: %s",
+                    pattern,
+                    ", ".join(matched),
+                )
+
+            if errors:
+                for err in errors:
+                    logger.error(err)
+                raise ValidationError(
+                    "One or more --set-regex patterns were invalid or matched nothing"
+                )
+
+            # Replace CLI --set with expanded list
+            setattr(self.cli_args, "set", resolved_sets)
+
+        except Exception as e:
+            # Surface as validation error for consistent handling
+            if isinstance(e, (ValidationError, ConfigurationError)):
+                raise
+            logger.critical(f"Failed to process --set-regex: {e}")
+            raise ValidationError("Failed to process --set-regex")
 
     def _validate_effective_configuration(self):
         """Validate required values after resolving effective configuration.


### PR DESCRIPTION
* instead of invoking multiple sets with the same prefix (different paths) have regex acceptable with --set-regex