### PR TITLE
fix tmt envars, parallel limit

### DIFF
--- a/src/enge/dispatch/set_flow.py
+++ b/src/enge/dispatch/set_flow.py
@@ -224,9 +224,15 @@ def process_request_spec(
     submit_test.business_unit_tag = resolved_opts.testing_farm.get(
         "cloud_resources_tag"
     )
-    submit_test.parallel_limit = effective_values.get(
-        "parallel_limit"
-    ) or resolved_opts.tests.get("parallel_limit")
+    # Parallel limit precedence for both set and non-set flows:
+    # 1) per-request effective (CLI > set > config when available)
+    # 2) globally resolved parsed_opts.parallel_limit (handles non-set flow)
+    # 3) fallback to top-level [tests].parallel_limit
+    submit_test.parallel_limit = (
+        effective_values.get("parallel_limit")
+        or getattr(resolved_opts, "parallel_limit", None)
+        or resolved_opts.tests.get("parallel_limit")
+    )
     submit_test.print_header = idx == 1
 
     # Auto tags if enabled
@@ -316,6 +322,7 @@ def process_request_spec(
         f"{target_spec['major']}.{target_spec['minor']}",
         source_spec["compose_name"],
         target_spec["compose_name"],
+        event=per_set_event,
     )
     # Enrich TMT context with target compose if URL provided
     if "TARGET_COMPOSE_URL" in merged_env_vars:

--- a/src/enge/utils/opt_manager.py
+++ b/src/enge/utils/opt_manager.py
@@ -986,6 +986,7 @@ class ParsedOpts:
                 f"{self.target_spec['major']}.{self.target_spec['minor']}",
                 self.source_spec["compose_name"],
                 self.target_spec["compose_name"],
+                event=effective_values.get("event"),
             )
 
             # Parse architectures with effective values

--- a/src/enge/utils/source_target_parser.py
+++ b/src/enge/utils/source_target_parser.py
@@ -11,6 +11,7 @@ from typing import Dict, Tuple, Optional, Any, List
 from logging import getLogger
 
 from enge.utils.globals import TMT_PLUGIN_REPORT_REPORTPORTAL_PREFIX
+from enge.utils.globals import RP_COMPATIBLE_EVENT
 from enge.utils.errors import ValidationError
 
 LOGGER = getLogger(__name__)
@@ -662,6 +663,7 @@ def merge_set_environment_variables(
     target_release: Optional[str] = None,
     source_compose: Optional[str] = None,
     target_compose: Optional[str] = None,
+    event: Optional[str] = None,
 ) -> Dict[str, str]:
     """
     Merge environment variables from automatic generation, test sets, CLI, and ReportPortal config.
@@ -688,7 +690,11 @@ def merge_set_environment_variables(
     merged_vars = auto_env_vars.copy()
 
     # Add ReportPortal environment variables first (lowest priority)
-    if config or set_reportportal_config:
+    # Only when event is present and compatible
+    effective_event = event or (getattr(cli_args, "event", None) if cli_args else None)
+    rp_enabled = bool(effective_event) and effective_event in RP_COMPATIBLE_EVENT
+
+    if rp_enabled and (config or set_reportportal_config):
         # Create a merged reportportal config with test set values taking precedence
         reportportal_config = {}
         base_rp_config = {}
@@ -727,7 +733,7 @@ def merge_set_environment_variables(
             target_release,
             source_compose,
             target_compose,
-            event=None,  # This call doesn't have event context available
+            event=effective_event,
         )
         # Merge with warnings and ignore empty overrides
         for k, v in reportportal_vars.items():


### PR DESCRIPTION
* do not generate tmt envars (RP) when no or not compatible event triggered
* fix parallel_limit global default; config/set overrides