### PR TITLE
Address user feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ Reads the same input as the report module - `--file`, `--input` or `--get-tag` (
 Use `--error` or `--fail` if you want to further specify which type of non-zero result you want to re-run, default is both results. If the whole task reports state error, the original plan filtering will be used, otherwise each of the failing/erroring plans will be passed to the plan name field connected by a pipe `|`, meaning all qualified plans from a single original request will be sent as one request for a re-run.<br>
 Use `--dryrun` to only display the qualified plans, don't actually send any payload to the Testing Farm.<br>
 Use `--set-tag` to label the archived jobs file.
+When rerun pulls UUIDs from an archived file (direct path or `--get-tag`), the newly archived rerun file inherits all original tags and appends a `.rerun` suffix automatically so follow-up runs stay linked to their source.
 
 For detailed information about task archiving and tagging functionality, see the [Task Archiving and Tagging](#task-archiving-and-tagging) section.
 

--- a/README.md
+++ b/README.md
@@ -632,6 +632,7 @@ The `--set-tag`, `--auto-tag`, and `--get-tag` options provide a powerful way to
   - **Sets**: Creates combined tags like `setname.architecture.tier` for precise identification
   - **Tiers**: Creates combined tags like `architecture.tier` when no set is specified
   - **Plans**: Creates tags for architecture (when single architecture is configured)
+  - **Detailed Upgrade Path**: Adds a detailed source→target shorthand (e.g., `98to102` for 9.8→10.2) so inherited rerun archives can be traced back to their exact release pair.
 - Can be combined with `--set-tag` for additional custom tags
 - **Generates separate archive files** - each unique tag combination creates its own file
 - Particularly useful for test sets with multiple tier/architecture combinations as it creates granular, organized files

--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ enge ships with a default configuration used as a base for all settings. Default
 
 >__NOTE__: Pre-configured default configuration file will be distributed in the leapp-tests repository.
 
+If you maintain the default configuration in a different location (for example,
+checked out from a private repository), point enge to it by adding
+`default_config_path = '/path/to/enge_default_config.toml'` either at the root of
+your `enge.toml` or inside the `[common]` section. When set, this path takes
+precedence over the system-wide default.
+
 If both are present, enge compares their `version` fields (semantic-like `X.Y.Z`, e.g. `2025.08.27`), and **logs a warning** when the system default under `/etc/enge/enge_default_config.toml` appears older than the bundled example, suggesting an update.
 
 Key default paths from the bundled defaults (can be overridden in your `enge.toml`):

--- a/src/enge/dispatch/set_flow.py
+++ b/src/enge/dispatch/set_flow.py
@@ -5,6 +5,7 @@ from typing import List, Dict, Any, Optional
 from enge.utils.source_target_parser import (
     parse_source_target_config,
     generate_upgrade_path_alias,
+    generate_detailed_upgrade_path_alias,
     parse_architectures,
     generate_tier_plan_filter,
     generate_environment_variables,
@@ -57,6 +58,7 @@ class RequestSpec:
     source_spec: Dict[str, Any]
     target_spec: Dict[str, Any]
     upgrade_path: str
+    upgrade_path_detailed: Optional[str] = None
     effective_values: Dict[str, Any]
 
 
@@ -89,6 +91,9 @@ def expand_set_requests() -> List[RequestSpec]:
                 source_value, target_value, resolved_opts.config
             )
             upgrade_path = generate_upgrade_path_alias(source_spec, target_spec)
+            detailed_upgrade_path = generate_detailed_upgrade_path_alias(
+                source_spec, target_spec
+            )
         except ValueError as e:
             LOGGER.error(
                 f"Failed to parse configuration for test set '{set_name}': {e}"
@@ -126,6 +131,7 @@ def expand_set_requests() -> List[RequestSpec]:
                                 source_spec=source_spec,
                                 target_spec=target_spec,
                                 upgrade_path=upgrade_path,
+                                upgrade_path_detailed=detailed_upgrade_path,
                                 effective_values=effective_values,
                             )
                         )
@@ -139,6 +145,7 @@ def expand_set_requests() -> List[RequestSpec]:
                             source_spec=source_spec,
                             target_spec=target_spec,
                             upgrade_path=upgrade_path,
+                            upgrade_path_detailed=detailed_upgrade_path,
                             effective_values=effective_values,
                         )
                     )
@@ -162,6 +169,7 @@ def process_request_spec(
     source_spec = spec.source_spec
     target_spec = spec.target_spec
     upgrade_path = spec.upgrade_path
+    upgrade_path_detailed = spec.upgrade_path_detailed
     arch = spec.arch
     effective_values = spec.effective_values
 
@@ -236,7 +244,12 @@ def process_request_spec(
     submit_test.print_header = idx == 1
 
     # Auto tags if enabled
-    submit_test.set_auto_tags(set_name=set_name, architecture=arch, tier=tier)
+    submit_test.set_auto_tags(
+        set_name=set_name,
+        architecture=arch,
+        tier=tier,
+        upgrade_path_tag=upgrade_path_detailed,
+    )
 
     # Plan filter
     try:

--- a/src/enge/dispatch/tf_send_request.py
+++ b/src/enge/dispatch/tf_send_request.py
@@ -150,14 +150,16 @@ class SubmitTest:
         set_name: Optional[str] = None,
         architecture: Optional[str] = None,
         tier: Optional[str] = None,
+        upgrade_path_tag: Optional[str] = None,
     ):
         """
-        Set auto-generated tags based on set name, architecture, and tier.
+        Set auto-generated tags based on set name, architecture, tier, and detailed upgrade path.
 
         Args:
             set_name: Name of the test set (optional)
             architecture: Target architecture (optional)
             tier: Test tier (optional)
+            upgrade_path_tag: Detailed upgrade path alias (e.g., "98to102")
         """
         if not self.auto_tag_enabled:
             return
@@ -179,6 +181,9 @@ class SubmitTest:
                 auto_tags.append(architecture)
             if tier:
                 auto_tags.append(tier)
+
+        if upgrade_path_tag:
+            auto_tags.append(upgrade_path_tag)
 
         self.auto_generated_tags = auto_tags
         LOGGER.debug(f"Generated auto tags: {auto_tags}")

--- a/src/enge/report/__main__.py
+++ b/src/enge/report/__main__.py
@@ -196,7 +196,9 @@ def build_table_comparison():
     # Sort UUIDs by architecture first, then by creation date within each architecture
     def get_arch_and_timestamp(uuid):
         data = parsed_dict[uuid]
-        arch = data["testsuites"][0]["testsuite_arch"] if data["testsuites"] else "Unknown"
+        arch = (
+            data["testsuites"][0]["testsuite_arch"] if data["testsuites"] else "Unknown"
+        )
         created = data.get("created", "")
         return (arch, created)
 
@@ -209,7 +211,9 @@ def build_table_comparison():
     for i, uuid in enumerate(uuids, 1):
         data = parsed_dict[uuid]
         # Get architecture from first testsuite or default to Unknown
-        arch = data["testsuites"][0]["testsuite_arch"] if data["testsuites"] else "Unknown"
+        arch = (
+            data["testsuites"][0]["testsuite_arch"] if data["testsuites"] else "Unknown"
+        )
         # Use format: "arch (index)" for cleaner headers
         header = f"{arch} ({i})"
         headers.append(header)
@@ -474,10 +478,11 @@ def main(result_table=None):
                     )
                 )
                 for index, info in metadata.items():
-                    if isinstance(info, dict) and 'uuid' in info:
+                    if isinstance(info, dict) and "uuid" in info:
                         print(
                             FormatText.format_text(
-                                f"({index}) {info['arch']}: {info['url']}", text_col=FormatText.DIM
+                                f"({index}) {info['arch']}: {info['url']}",
+                                text_col=FormatText.DIM,
                             )
                         )
 

--- a/src/enge/rerun/__main__.py
+++ b/src/enge/rerun/__main__.py
@@ -1,7 +1,8 @@
 import logging
 import os
 import sys
-from typing import Optional, Dict, Any
+from pathlib import Path
+from typing import Optional, Dict, Any, Iterable, List
 
 from enge.utils.http_client import http_get
 from prettytable import PrettyTable
@@ -9,10 +10,9 @@ from prettytable import PrettyTable
 from enge.dispatch.tf_send_request import SubmitTest
 from enge.report.__main__ import parse_tasks, parse_request_xunit
 from enge.utils.opt_manager import parsed_opts
-from enge.utils.globals import REQUEST_TIMEOUT_DEFAULT
+from enge.utils.globals import REQUEST_TIMEOUT_DEFAULT, RP_COMPATIBLE_EVENT
 from enge.utils import FormatText
 from enge.utils.reportportal_helper import create_launch as rp_create_launch
-from enge.utils.globals import RP_COMPATIBLE_EVENT
 
 colorize = FormatText()
 
@@ -21,6 +21,99 @@ logger = logging.getLogger(__name__)
 # Don't print unnecessary log messages from the report module
 report_logger = logging.getLogger("enge.report")
 report_logger.setLevel(logging.WARNING)
+
+
+def _unique_preserve(values: Iterable[str]) -> List[str]:
+    """Return values with duplicates removed while preserving their order."""
+    seen = set()
+    ordered: List[str] = []
+    for value in values:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+def _resolve_archive_sources(
+    task_source: Optional[Any],
+    archive_default_path: Optional[str],
+    cli_args: Any,
+) -> List[Path]:
+    """
+    Resolve archive file paths that were used as rerun inputs.
+
+    Args:
+        task_source: Metadata returned by parse_tasks (file list, filenames, or None)
+        archive_default_path: Configured archive directory path
+
+    Returns:
+        List of Path objects pointing to archive files associated with the rerun input.
+    """
+    paths: List[Path] = []
+
+    file_args = getattr(cli_args, "file", None) or []
+    for entry in file_args:
+        if entry:
+            paths.append(Path(entry).expanduser())
+
+    get_tag_args = getattr(cli_args, "get_tag", None)
+    if get_tag_args and task_source and archive_default_path:
+        if isinstance(task_source, str):
+            filenames = [task_source]
+        else:
+            filenames = list(task_source)
+        archive_root = Path(archive_default_path).expanduser()
+        for filename in filenames:
+            if filename:
+                paths.append(archive_root / filename)
+
+    return paths
+
+
+def _extract_tags_from_filename(path: Path) -> List[str]:
+    """Extract appended tags from an archive filename."""
+    name = path.name
+    if "." not in name:
+        return []
+    _, *tag_parts = name.split(".")
+    return [part for part in tag_parts if part]
+
+
+def _collect_inherited_tags(
+    task_source: Optional[Any],
+    cli_args: Optional[Any] = None,
+    archive_default_path: Optional[str] = None,
+) -> List[str]:
+    """
+    Collect tags from archive files referenced by the rerun command.
+
+    Returns:
+        Ordered list of inherited tags with the 'rerun' marker appended when applicable.
+    """
+    archive_paths = _resolve_archive_sources(
+        task_source,
+        (
+            archive_default_path
+            if archive_default_path is not None
+            else getattr(parsed_opts, "archive_tasks_default", None)
+        ),
+        cli_args or parsed_opts.cli_args,
+    )
+    if not archive_paths:
+        return []
+
+    inherited: List[str] = []
+    for archive_path in archive_paths:
+        inherited.extend(_extract_tags_from_filename(archive_path))
+
+    inherited.append("rerun")
+    tags = _unique_preserve(inherited)
+
+    if tags:
+        logger.debug("Inheriting archive tags for rerun: %s", tags)
+
+    return tags
 
 
 class RerunJobs:
@@ -466,6 +559,8 @@ def main():
     # Build re-run payloads (extract data from original requests)
     jobs.build_rerun_payloads(jobs.rerun_uuids)
 
+    inherited_tags = _collect_inherited_tags(jobs.task_source)
+
     # Extract context from the first payload's original task for ReportPortal launch
     event_name = None
     tier = None
@@ -608,6 +703,11 @@ def main():
 
     # Set up the submitter (only for API key and headers)
     submit = SubmitTest()
+    if inherited_tags:
+        existing_tags = submit.set_tag or []
+        combined_tags = _unique_preserve([*existing_tags, *inherited_tags])
+        submit.set_tag = combined_tags
+        logger.info("Archiving rerun tasks with tags: %s", ", ".join(combined_tags))
     submit.print_header = True
     submit.api_key = parsed_opts.testing_farm.get("api_key")
 

--- a/src/enge/utils/config_parser.py
+++ b/src/enge/utils/config_parser.py
@@ -39,9 +39,15 @@ def _parse_version(version_val: Any) -> Optional[tuple[int, int, int]]:
     return None
 
 
-def load_default_config() -> Dict[str, Any]:
+def load_default_config(
+    user_override: Optional[Union[str, Path]] = None,
+) -> Dict[str, Any]:
     """
     Load the built-in default configuration.
+
+    Args:
+        user_override: Optional path provided by user configuration that should
+            be treated as the default configuration source.
 
     Returns:
         Default configuration dictionary
@@ -49,6 +55,15 @@ def load_default_config() -> Dict[str, Any]:
     Raises:
         SystemExit: If default config cannot be loaded
     """
+    user_override_path: Optional[Path] = None
+    if user_override:
+        try:
+            user_override_path = Path(user_override).expanduser()
+        except TypeError:
+            LOGGER.warning(
+                "Ignoring default configuration override because it is not a valid path"
+            )
+
     # Preferred external default at /etc/enge/enge_default_config.toml
     external_path = Path("/etc/enge/enge_default_config.toml")
     # Fallbacks to package-bundled example and dev path
@@ -59,11 +74,24 @@ def load_default_config() -> Dict[str, Any]:
     except Exception:
         bundled_path = Path(__file__).parent / "enge_default_config.toml"
 
+    override_cfg = None
+    if user_override_path:
+        override_cfg = _safe_load_toml(user_override_path)
+        if override_cfg:
+            LOGGER.info(
+                f"Using user-defined default configuration at {user_override_path}"
+            )
+        else:
+            LOGGER.warning(
+                f"User-defined default configuration {user_override_path} is "
+                "not readable; falling back"
+            )
+
     external_cfg = _safe_load_toml(external_path)
     bundled_cfg = _safe_load_toml(bundled_path) if bundled_path else None
 
     # Version comparison warning: warn only if external exists and is older than bundled
-    if external_cfg and bundled_cfg:
+    if override_cfg is None and external_cfg and bundled_cfg:
         ext_ver = _parse_version(external_cfg.get("version"))
         bun_ver = _parse_version(bundled_cfg.get("version"))
         if ext_ver and bun_ver and ext_ver < bun_ver:
@@ -73,6 +101,8 @@ def load_default_config() -> Dict[str, Any]:
             )
 
     # Selection: prefer external when present
+    if override_cfg:
+        return override_cfg
     if external_cfg:
         return external_cfg
     if bundled_cfg:
@@ -135,9 +165,6 @@ def load_config(paths: Union[List[str], List[Path]]) -> Dict[str, Any]:
         LOGGER.critical("No configuration file paths provided")
         raise ConfigurationError("No configuration file paths provided")
 
-    # Load default configuration
-    default_config = load_default_config()
-
     # Append system/user paths in priority order if not already present
     expanded_paths = [Path(path).expanduser() for path in paths]
     for p in DEFAULT_USER_CONFIG_PATHS:
@@ -166,6 +193,34 @@ def load_config(paths: Union[List[str], List[Path]]) -> Dict[str, Any]:
             except OSError as e:
                 LOGGER.warning(f"Error reading config file {path}: {e}")
                 continue
+
+    default_override_path: Optional[Union[str, Path]] = None
+    override_source = "root"
+    if user_config:
+        override_candidate = user_config.get("default_config_path")
+        if override_candidate is None:
+            common_section = user_config.get("common")
+            if isinstance(common_section, dict):
+                override_candidate = common_section.get("default_config_path")
+                if override_candidate is not None:
+                    override_source = "[common]"
+        if isinstance(override_candidate, (str, Path)):
+            override_text = str(override_candidate).strip()
+            if override_text:
+                default_override_path = override_text
+            else:
+                LOGGER.warning(
+                    f"Ignoring default_config_path override in {override_source} "
+                    "because it is empty"
+                )
+        elif override_candidate is not None:
+            LOGGER.warning(
+                f"Ignoring default_config_path override in {override_source} "
+                "because it must be a string path"
+            )
+
+    # Load default configuration, honoring user override if provided
+    default_config = load_default_config(default_override_path)
 
     if user_config is None:
         # No user config found, use defaults only

--- a/src/enge/utils/enge_default_config.toml
+++ b/src/enge/utils/enge_default_config.toml
@@ -5,7 +5,7 @@
 # - User configuration files (enge.toml) override these defaults.
 # - Use this file as a reference for available keys and default values.
 # ============================================================================
-version = '2025.08.27'
+version = '2025.11.18'
 
 # ============================================================================
 # COMMON (Global paths and storage locations - defaults)

--- a/src/enge/utils/source_target_parser.py
+++ b/src/enge/utils/source_target_parser.py
@@ -163,6 +163,38 @@ def generate_upgrade_path_alias(
     return f"{source_spec['major']}to{target_spec['major']}"
 
 
+def generate_detailed_upgrade_path_alias(
+    source_spec: Dict[str, Any], target_spec: Dict[str, Any]
+) -> Optional[str]:
+    """
+    Generate detailed upgrade path alias including minor versions (e.g., "98to102").
+
+    Args:
+        source_spec: Source specification dictionary
+        target_spec: Target specification dictionary
+
+    Returns:
+        Detailed upgrade path alias string or None if components are missing
+    """
+
+    def _format(spec: Dict[str, Any]) -> Optional[str]:
+        major = spec.get("major")
+        minor = spec.get("minor")
+        if major is None or minor is None:
+            return None
+        try:
+            return f"{int(major)}{int(minor)}"
+        except (TypeError, ValueError):
+            return None
+
+    source_alias = _format(source_spec)
+    target_alias = _format(target_spec)
+    if not source_alias or not target_alias:
+        return None
+
+    return f"{source_alias}to{target_alias}"
+
+
 def generate_environment_variables(
     source_spec: Dict[str, Any],
     target_spec: Dict[str, Any],

--- a/tests/test_auto_tagging.py
+++ b/tests/test_auto_tagging.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+from enge.utils.source_target_parser import generate_detailed_upgrade_path_alias
+
+
+def test_generate_detailed_upgrade_path_alias():
+    source = {"major": 9, "minor": 8}
+    target = {"major": 10, "minor": 2}
+    assert generate_detailed_upgrade_path_alias(source, target) == "98to102"
+
+
+def test_set_auto_tags_includes_upgrade_path(monkeypatch):
+    from enge.dispatch import tf_send_request
+
+    parsed_stub = SimpleNamespace(
+        cli_args=SimpleNamespace(set_tag=None, auto_tag=True),
+        testing_farm_endpoint=SimpleNamespace(
+            log_artifact_baseurl="http://logs", api_endpoint_url="http://api"
+        ),
+    )
+    monkeypatch.setattr(tf_send_request, "parsed_opts", parsed_stub)
+
+    submit = tf_send_request.SubmitTest()
+    submit.set_auto_tags(
+        set_name="pre-release",
+        architecture="x86_64",
+        tier="tier0",
+        upgrade_path_tag="98to102",
+    )
+
+    assert submit.auto_generated_tags[-1] == "98to102"
+    assert "pre-release" in ".".join(submit.auto_generated_tags)

--- a/tests/test_rerun_tags.py
+++ b/tests/test_rerun_tags.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+
+from enge.rerun.__main__ import _collect_inherited_tags
+
+
+def test_collect_inherited_tags_from_file_inputs():
+    cli_args = SimpleNamespace(
+        file=["/tmp/archive/enge_jobs_archive_1.tier0.x86_64"], get_tag=None
+    )
+    tags = _collect_inherited_tags(
+        task_source=None,
+        cli_args=cli_args,
+        archive_default_path="/tmp/archive",
+    )
+    assert tags == ["tier0", "x86_64", "rerun"]
+
+
+def test_collect_inherited_tags_from_get_tag_sources(tmp_path):
+    archive_file_names = [
+        "enge_jobs_archive_1.pre-release.x86_64.tier0",
+        "enge_jobs_archive_1.pre-release.aarch64.tier0",
+    ]
+    cli_args = SimpleNamespace(file=None, get_tag=["pre-release"])
+    tags = _collect_inherited_tags(
+        task_source=archive_file_names,
+        cli_args=cli_args,
+        archive_default_path=str(tmp_path),
+    )
+    # Tags are deduplicated but order is preserved
+    assert tags == ["pre-release", "x86_64", "tier0", "aarch64", "rerun"]
+
+
+def test_collect_inherited_tags_without_suffix():
+    cli_args = SimpleNamespace(file=["/tmp/archive/enge_jobs_archive_1"], get_tag=None)
+    tags = _collect_inherited_tags(
+        task_source=None,
+        cli_args=cli_args,
+        archive_default_path="/tmp/archive",
+    )
+    assert tags == ["rerun"]


### PR DESCRIPTION
* default config path can be configured in user config (e.g. point to local clone of leapp-tests)
* rerun archive file inherits tags from original, suffixes with `.rerun`
* detailed upgrade path (extracted from source and target /e.g. 98to102/) added as a unique tag