### PR TITLE
Repin compose if provided not available

### DIFF
--- a/src/enge/dispatch/pin_compose.py
+++ b/src/enge/dispatch/pin_compose.py
@@ -385,3 +385,68 @@ def _pin_compose(compose_arg, composes_prod_url):
         _show_compose_not_found_error(attempted_composes, data, major, minor)
 
     return compose_arg if compose_arg in (data.get("COMPOSES") or []) else compose
+
+
+_repin_cache = {}
+
+
+def repin_compose(compose_name, composes_prod_url):
+    """
+    Re-pin a compose name to the latest available nightly version.
+
+    Extracts major.minor from the original compose name and resolves it
+    to the current nightly compose via the Testing Farm composes API.
+
+    Results are cached per (compose_name, composes_prod_url) to avoid
+    duplicate API requests and warnings when the same compose is validated
+    multiple times (e.g., opt_manager + set_flow).
+
+    Non-RHEL composes (e.g., CentOS-Stream-9) are returned as-is since
+    they are already symbolic and don't require re-pinning.
+
+    Parameters:
+    - compose_name (str): Original compose name (e.g., "RHEL-8.10.0-20241215.1")
+    - composes_prod_url (str): URL to fetch compose data from.
+
+    Returns:
+    - str: Updated compose name for RHEL composes, or the original name for non-RHEL.
+
+    Raises:
+    - ValueError: If composes_prod_url is not configured or compose name cannot be parsed.
+    - ValidationError: If the compose cannot be resolved to an available nightly
+      (propagated from _pin_compose_with_fallback).
+    """
+    cache_key = (compose_name, composes_prod_url)
+    if cache_key in _repin_cache:
+        return _repin_cache[cache_key]
+
+    if not compose_name:
+        raise ValueError("Compose name is empty, cannot re-pin")
+
+    # Non-RHEL composes (e.g., CentOS-Stream-9) are already symbolic
+    if not compose_name.startswith("RHEL-"):
+        LOGGER.debug("Non-RHEL compose does not require re-pinning: %s", compose_name)
+        _repin_cache[cache_key] = compose_name
+        return compose_name
+
+    # Extract major.minor from compose name
+    # Handles both RHEL-8.10.0-suffix and RHEL-10.1-suffix formats
+    match = re.match(r"^RHEL-(\d+)\.(\d+)(?:\.\d+)?-(.+)$", compose_name)
+    if not match:
+        raise ValueError(f"Could not parse compose name for re-pinning: {compose_name}")
+
+    major = int(match.group(1))
+    minor = int(match.group(2))
+
+    if not composes_prod_url:
+        raise ValueError(
+            "composes_prod_url is not configured, cannot validate compose availability"
+        )
+
+    result = _pin_compose_with_fallback(major, minor, composes_prod_url)
+    if result != compose_name:
+        LOGGER.warning("Compose re-pinned: %s -> %s", compose_name, result)
+    else:
+        LOGGER.debug("Compose validated: %s", compose_name)
+    _repin_cache[cache_key] = result
+    return result

--- a/src/enge/rerun/__main__.py
+++ b/src/enge/rerun/__main__.py
@@ -1,7 +1,6 @@
 import copy
 import logging
 import os
-import sys
 from pathlib import Path
 from typing import Optional, Dict, Any, Iterable, List
 from datetime import datetime
@@ -9,6 +8,7 @@ from datetime import datetime
 from enge.utils.http_client import http_get
 from prettytable import PrettyTable
 
+from enge.dispatch.pin_compose import repin_compose
 from enge.dispatch.tf_send_request import SubmitTest
 from enge.report.__main__ import parse_tasks_with_map, parse_request_xunit
 from enge.utils.opt_manager import parsed_opts
@@ -597,6 +597,14 @@ class RerunJobs:
             filtered_payload["environments"] = filtered_payload.pop(
                 "environments_requested"
             )
+
+            # Re-pin compose to the latest available nightly
+            env = filtered_payload["environments"][0]
+            original_compose = env.get("os", {}).get("compose")
+            composes_prod_url = parsed_opts.config.get("testing_farm", {}).get(
+                "composes_prod_url", ""
+            )
+            env["os"]["compose"] = repin_compose(original_compose, composes_prod_url)
 
             # Append the filtered payload for re-run
             self.rerun_payloads.append(filtered_payload)

--- a/src/enge/utils/source_target_parser.py
+++ b/src/enge/utils/source_target_parser.py
@@ -96,9 +96,9 @@ def parse_compose_spec(
                 compose_name = translated_compose
             except Exception as e:
                 LOGGER.warning(
-                    f"Failed to translate compose for {major}.{minor}: {e}. Using fallback."
+                    f"Failed to translate compose for {major}.{minor}: {e}. "
+                    "Using symbolic compose name, the provisioner will resolve it."
                 )
-                # Fallback to standard format
                 compose_name = f"RHEL-{major}.{minor}.0-Nightly"
         else:
             LOGGER.debug(
@@ -117,29 +117,15 @@ def parse_compose_spec(
         }
 
     # Try parsing as full compose name (e.g., "RHEL-8.10.0-Nightly")
-    compose_match = re.match(r"^RHEL-(\d+)\.(\d+)\.(\d+)-(.+)$", spec.strip())
+    compose_match = re.match(r"^RHEL-(\d+)\.(\d+)(?:\.(\d+))?-(.+)$", spec.strip())
     if compose_match:
         major = int(compose_match.group(1))
         minor = int(compose_match.group(2))
-        # For compose names, validate them against COMPOSES_PROD_URL
 
-        from enge.dispatch.pin_compose import _pin_compose
+        from enge.dispatch.pin_compose import repin_compose
 
-        compose_name = spec.strip()
         composes_prod_url = config.get("testing_farm", {}).get("composes_prod_url", "")
-
-        if composes_prod_url:
-            try:
-                # Use _pin_compose for validation - it will exit if compose is not found
-                validated_compose = _pin_compose(compose_name, composes_prod_url)
-                LOGGER.debug(
-                    f"Validated compose {compose_name} against COMPOSES_PROD_URL"
-                )
-                compose_name = validated_compose
-            except Exception as e:
-                LOGGER.warning(
-                    f"Failed to validate compose {compose_name}: {e}. Using as provided."
-                )
+        compose_name = repin_compose(spec.strip(), composes_prod_url)
 
         return {
             "major": major,


### PR DESCRIPTION
* if the compose is outdated and not available at the composes_variables endpoint, check for newer one and pin that
* applies for both test and rerun