### PR TITLE
Add --delete-stale and --since/--until date filters for reportportal …

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,47 @@ enge reportportal --delete-logs --all-launches
 enge reportportal --delete-logs --all-launches --dryrun
 ```
 
+**Deleting Stale Launches (`--delete-stale`):**
+
+Delete launches that are stopped or interrupted and have no test items — empty launches left behind by failed or aborted dispatches.
+
+```bash
+# Delete all stale launches
+enge reportportal --delete-stale
+
+# Preview which launches would be deleted
+enge reportportal --delete-stale --dryrun
+
+# Only stale launches started before a given date
+enge reportportal --delete-stale --until 2025-12-31
+
+# Combine both bounds
+enge reportportal --delete-stale --since 2025-01-01 --until 2025-06-30
+```
+
+**Date Filters (`--since` / `--until`):**
+
+Narrow any launch-listing operation by date. Accepts absolute dates (`YYYY-MM-DD`) or relative aliases (`6h`, `3d`, `2w`, `1m`, `1y` — meaning "that many units ago from now"). Effective with `--all-launches` and `--delete-stale`; ignored for task-based operations.
+
+```bash
+# Finish only launches started after a date
+enge reportportal --finish --all-launches --since 2025-07-01
+
+# Delete stale launches from the last 3 days
+enge reportportal --delete-stale --since 3d
+
+# Delete stale launches older than 2 weeks
+enge reportportal --delete-stale --until 2w
+
+# Enrich launches within a relative window
+enge reportportal --enrich-logs --all-launches --since 1m
+
+# Mix absolute and relative
+enge reportportal --enrich-logs --all-launches --since 2025-01-01 --until 3m
+```
+
+The same `--since` / `--until` flags are also available on the `report` subcommand — see [Report](#report).
+
 **Testing Connection (`--test`):**
 
 Verify your ReportPortal configuration and connectivity.
@@ -656,6 +697,7 @@ All task-based operations (`--finish`, `--enrich-logs`, `--delete-logs` without 
 | `--enrich-logs --all-launches` | All statuses | Enriches every launch; skips already-enriched (`logs_attached`) |
 | `--finish --enrich-logs --all-launches` | IN_PROGRESS | Enriches first, then finishes |
 | `--delete-logs --all-launches` | IN_PROGRESS | Deletes all logs from each launch |
+| `--delete-stale` | STOPPED / INTERRUPTED | Deletes empty launches (no test items); standalone, no `--all-launches` needed |
 
 ##### Report
 With the report command you are able to get the results of the requested jobs straight to the command line.<br>
@@ -685,6 +727,21 @@ enge report --show-tests --input 9f42645f-bcaa-4c73-87e2-6e1efef16635 --short
 
 # Display only UUIDs from the requested inputs
 enge report --show-ids --file ~/my_jobs_file
+```
+
+**Date Filters (`--since` / `--until`):**
+
+When used with `--get-tag`, `--since` and `--until` filter archived task files by the timestamp embedded in their filename (`enge_jobs_archive_YYYYMMDDHHMMSS`). Accepts absolute dates (`YYYY-MM-DD`) or relative aliases (`6h`, `3d`, `2w`, `1m`, `1y`). Files provided via `-f` or `-i` are not filtered.
+
+```bash
+# Report only archives from the last week
+enge report --get-tag regression --since 1w
+
+# Report archives within a date range
+enge report --get-tag tier0 --since 2025-01-01 --until 2025-06-30
+
+# Report archives from the last 12 hours
+enge report --get-tag smoke --since 12h
 ```
 
 ## Troubleshooting configuration and validation

--- a/src/enge/report/__main__.py
+++ b/src/enge/report/__main__.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import uuid
+from datetime import datetime
 
 from prettytable import PrettyTable
 
@@ -25,6 +26,31 @@ ERROR_HERE = 3
 NO_RESULT = 4
 
 LOGGER = logging.getLogger(__name__)
+
+_ARCHIVE_TS_RE = re.compile(r"enge_jobs_archive_(\d{14})")
+
+
+def _file_in_date_range(
+    filename: str,
+    since: "datetime | None",
+    until: "datetime | None",
+) -> bool:
+    """Check whether an archive file's timestamp falls within a date range.
+
+    Extracts the ``YYYYMMDDHHMMSS`` timestamp embedded in the standard
+    archive filename.  Files that don't match the naming convention are
+    passed through unfiltered.
+    """
+    m = _ARCHIVE_TS_RE.search(filename)
+    if not m:
+        return True
+
+    file_dt = datetime.strptime(m.group(1), "%Y%m%d%H%M%S")
+    if since and file_dt < since:
+        return False
+    if until and file_dt > until:
+        return False
+    return True
 
 
 def _latest_tasks_file():
@@ -63,33 +89,57 @@ def _parse_tasks_impl():
 
                     raise ValidationError("Input file does not exist")
 
-        if parsed_opts.cli_args.get_tag:
+        since_str = getattr(parsed_opts.cli_args, "since", None)
+        until_str = getattr(parsed_opts.cli_args, "until", None)
+        has_tags = bool(parsed_opts.cli_args.get_tag)
+        has_date_filter = bool(since_str or until_str)
+
+        if has_tags or has_date_filter:
             default_path = parsed_opts.archive_tasks_default
             if not os.path.exists(default_path):
                 LOGGER.critical(f"The given path {default_path} does not exist!")
 
                 raise ValidationError("Archive path does not exist")
 
-            # Compile regex patterns for efficiency
             compiled_patterns = []
-            for tag in parsed_opts.cli_args.get_tag:
-                try:
-                    compiled_patterns.append(re.compile(tag))
-                except re.error as e:
-                    LOGGER.error(f"Invalid regex pattern '{tag}': {e}")
+            if has_tags:
+                for tag in parsed_opts.cli_args.get_tag:
+                    try:
+                        compiled_patterns.append(re.compile(tag))
+                    except re.error as e:
+                        LOGGER.error(f"Invalid regex pattern '{tag}': {e}")
 
-                    raise ValidationError("Invalid regex in --get-tag")
+                        raise ValidationError("Invalid regex in --get-tag")
 
             source = []
             for file in os.listdir(default_path):
-                file_extension = file.split(".", 1)[-1] if "." in file else ""
+                if compiled_patterns:
+                    file_extension = file.split(".", 1)[-1] if "." in file else ""
+                    if not any(
+                        pattern.search(file_extension) or pattern.search(file)
+                        for pattern in compiled_patterns
+                    ):
+                        continue
+                source.append(file)
 
-                # Check if any pattern matches the extension or full filename
-                if any(
-                    pattern.search(file_extension) or pattern.search(file)
-                    for pattern in compiled_patterns
-                ):
-                    source.append(file)
+            if has_date_filter:
+                from enge.utils import parse_date_arg
+
+                since_dt = parse_date_arg(since_str) if since_str else None
+                until_dt = (
+                    parse_date_arg(until_str).replace(hour=23, minute=59, second=59)
+                    if until_str
+                    else None
+                )
+                before = len(source)
+                source = [
+                    f for f in source if _file_in_date_range(f, since_dt, until_dt)
+                ]
+                if len(source) != before:
+                    LOGGER.info(
+                        f"Date filter narrowed {before} archive "
+                        f"file(s) to {len(source)}"
+                    )
 
             for file in source:
                 file = os.path.join(default_path, file)
@@ -101,7 +151,8 @@ def _parse_tasks_impl():
             (
                 parsed_opts.cli_args.file,
                 getattr(parsed_opts.cli_args, "input", None),
-                parsed_opts.cli_args.get_tag,
+                has_tags,
+                has_date_filter,
             )
         ):
             latest = _latest_tasks_file()

--- a/src/enge/reportportal/__main__.py
+++ b/src/enge/reportportal/__main__.py
@@ -459,7 +459,9 @@ class ReportPortalLaunch:
                     break
                 page += 1
 
-            LOGGER.info(f"Found {len(items)} test item(s) in launch {launch_id}")
+            LOGGER.debug(f"Found {len(items)} test item(s) in launch {launch_id}")
+            if getattr(parsed_opts.cli_args, "delete_stale", False) and len(items) == 0:
+                LOGGER.info(f"Found stale launch {launch_id} with no test items")
             if items:
                 for item in items[:10]:
                     LOGGER.debug(
@@ -850,12 +852,12 @@ class ReportPortalLaunch:
     # All-launches query helpers
     # ===================================================================
 
-    def get_all_in_progress_launches(self) -> List[Dict[str, Any]]:
-        """Fetch all IN_PROGRESS launches in the project (paginated)."""
+    def get_all_launches(self, status: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Fetch all launches in the project, optionally filtered by status."""
         all_launches: List[Dict[str, Any]] = []
         seen_ids: set = set()
         for page in range(1, 51):
-            launches = self.list_launches(size=50, page=page, status="IN_PROGRESS")
+            launches = self.list_launches(size=50, page=page, status=status)
             if not launches:
                 break
             for launch in launches:
@@ -863,11 +865,33 @@ class ReportPortalLaunch:
                 if lid and lid not in seen_ids:
                     seen_ids.add(lid)
                     all_launches.append(launch)
+        status_label = status or "any"
         LOGGER.info(
-            f"Found {len(all_launches)} IN_PROGRESS launch(es) "
-            f"in project '{self.project}'"
+            f"Found {len(all_launches)} launch(es) "
+            f"(status={status_label}) in project '{self.project}'"
         )
         return all_launches
+
+    def delete_launch(self, launch_id: int) -> bool:
+        """Delete a launch by its numeric ID."""
+        try:
+            response = http_delete(
+                f"{self.api_base}/launch/{launch_id}",
+                headers=self.headers,
+                timeout=30,
+            )
+            if response.status_code in (200, 204):
+                LOGGER.info(f"Deleted launch {launch_id}")
+                return True
+            else:
+                LOGGER.error(
+                    f"Failed to delete launch {launch_id}: "
+                    f"HTTP {response.status_code}"
+                )
+                return False
+        except RequestException as e:
+            LOGGER.error(f"Network error deleting launch {launch_id}: {e}")
+            return False
 
     def derive_launch_status(self, launch_id: int) -> str:
         """Derive an overall status for a launch from its test items."""
@@ -899,6 +923,7 @@ def main() -> int:
         test_connection_and_data,
         finish_all_in_progress_launches,
         delete_logs_all_launches,
+        delete_stale_launches,
     )
 
     try:
@@ -908,7 +933,13 @@ def main() -> int:
         wants_finish = getattr(parsed_opts.cli_args, "finish", False)
         wants_test = getattr(parsed_opts.cli_args, "test", False)
         wants_delete_logs = getattr(parsed_opts.cli_args, "delete_logs", False)
+        wants_delete_stale = getattr(parsed_opts.cli_args, "delete_stale", False)
         wants_all = getattr(parsed_opts.cli_args, "all_launches", False)
+
+        # --delete-stale (standalone, no task input needed)
+        if wants_delete_stale:
+            LOGGER.info("ReportPortal module - Deleting stale launches")
+            return delete_stale_launches(rp_launch)
 
         # --all-launches mode
         if wants_all:

--- a/src/enge/reportportal/operations.py
+++ b/src/enge/reportportal/operations.py
@@ -36,6 +36,7 @@ from enge.reportportal.utils import (
     show_dryrun_finish_data,
     show_dryrun_enrichment,
     show_dryrun_delete_logs,
+    show_dryrun_delete_stale,
 )
 
 if TYPE_CHECKING:
@@ -47,6 +48,52 @@ LOGGER = logging.getLogger(__name__)
 # ===================================================================
 # Internal helpers
 # ===================================================================
+
+
+def _apply_date_filters(
+    launches: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Narrow a list of launches using ``--since`` / ``--until`` CLI dates.
+
+    Compares each launch's ``startTime`` (epoch milliseconds) against
+    the user-supplied boundaries.  Returns the original list unchanged
+    when neither flag is set.
+    """
+    from enge.utils import parse_date_arg
+
+    since_str = getattr(parsed_opts.cli_args, "since", None)
+    until_str = getattr(parsed_opts.cli_args, "until", None)
+
+    if not since_str and not until_str:
+        return launches
+
+    since_ms: Optional[int] = None
+    until_ms: Optional[int] = None
+
+    if since_str:
+        since_ms = int(parse_date_arg(since_str).timestamp() * 1000)
+    if until_str:
+        until_dt = parse_date_arg(until_str).replace(hour=23, minute=59, second=59)
+        until_ms = int(until_dt.timestamp() * 1000)
+
+    filtered: List[Dict[str, Any]] = []
+    for launch in launches:
+        start_time = launch.get("startTime")
+        if start_time is None:
+            continue
+        if isinstance(start_time, str):
+            start_time = int(start_time)
+        if since_ms and start_time < since_ms:
+            continue
+        if until_ms and start_time > until_ms:
+            continue
+        filtered.append(launch)
+
+    if len(filtered) != len(launches):
+        LOGGER.info(
+            f"Date filter narrowed {len(launches)} launch(es) " f"to {len(filtered)}"
+        )
+    return filtered
 
 
 def _extract_tf_uuid(artifacts_url: str) -> Optional[str]:
@@ -677,7 +724,7 @@ def finish_all_in_progress_launches(rp: ReportPortalLaunch) -> int:
     """
     is_dryrun = getattr(parsed_opts.cli_args, "dryrun", False)
 
-    launches = rp.get_all_in_progress_launches()
+    launches = _apply_date_filters(rp.get_all_launches("IN_PROGRESS"))
     if not launches:
         LOGGER.info("No IN_PROGRESS launches found")
         return 0
@@ -795,7 +842,7 @@ def delete_logs_all_launches(rp: ReportPortalLaunch) -> int:
     """Delete logs from all IN_PROGRESS launches in the project."""
     is_dryrun = getattr(parsed_opts.cli_args, "dryrun", False)
 
-    launches = rp.get_all_in_progress_launches()
+    launches = _apply_date_filters(rp.get_all_launches("IN_PROGRESS"))
     if not launches:
         LOGGER.warning("No IN_PROGRESS launches found")
         return 1
@@ -876,30 +923,7 @@ def enrich_all_launches(
     max_size_str = rp.config.get("enrich_max_file_size", "5 MB")
     max_file_size = parse_size_string(str(max_size_str))
 
-    # Fetch launches — IN_PROGRESS only or all statuses
-    if status_filter == "IN_PROGRESS":
-        launches = rp.get_all_in_progress_launches()
-    else:
-        all_launches: List[Dict[str, Any]] = []
-        seen_ids: set = set()
-        for page in range(1, 51):
-            try:
-                batch = rp.list_launches(
-                    size=50,
-                    page=page,
-                    status=status_filter,
-                )
-            except Exception:
-                break
-            if not batch:
-                break
-            for launch in batch:
-                lid = launch.get("id")
-                if lid and lid not in seen_ids:
-                    seen_ids.add(lid)
-                    all_launches.append(launch)
-        launches = all_launches
-        LOGGER.info(f"Found {len(launches)} launch(es) to consider " f"for enrichment")
+    launches = _apply_date_filters(rp.get_all_launches(status=status_filter))
 
     if not launches:
         LOGGER.info("No launches found for enrichment")
@@ -1049,3 +1073,69 @@ def enrich_all_launches(
     else:
         LOGGER.info("No launches required enrichment")
     return 0
+
+
+# ===================================================================
+# --delete-stale
+# ===================================================================
+
+
+_STALE_STATUSES = ("STOPPED", "INTERRUPTED")
+
+
+def delete_stale_launches(rp: ReportPortalLaunch) -> int:
+    """
+    Delete stale launches — stopped/interrupted launches with no test items.
+
+    Fetches all STOPPED and INTERRUPTED launches, checks each for test
+    items, and deletes those that have none.
+    """
+    is_dryrun = getattr(parsed_opts.cli_args, "dryrun", False)
+
+    launches: List[Dict[str, Any]] = []
+    seen_ids: set = set()
+    for status in _STALE_STATUSES:
+        for launch in rp.get_all_launches(status):
+            lid = launch.get("id")
+            if lid and lid not in seen_ids:
+                seen_ids.add(lid)
+                launches.append(launch)
+    launches = _apply_date_filters(launches)
+
+    if not launches:
+        LOGGER.info("No STOPPED/INTERRUPTED launches found")
+        return 0
+
+    stale: List[Dict[str, Any]] = []
+    for launch in launches:
+        numeric_id = launch.get("id")
+        if numeric_id is None:
+            continue
+        items = rp.get_launch_test_items(numeric_id)
+        if not items:
+            stale.append(launch)
+
+    if not stale:
+        LOGGER.info(
+            f"No stale launches found among "
+            f"{len(launches)} STOPPED/INTERRUPTED launch(es)"
+        )
+        return 0
+
+    if is_dryrun:
+        show_dryrun_delete_stale(stale)
+        return 0
+
+    deleted = 0
+    for launch in stale:
+        launch_id = launch.get("id")
+        launch_name = launch.get("name", "Unknown")
+        launch_uuid = launch.get("uuid", "")
+        if rp.delete_launch(launch_id):
+            LOGGER.info(f"Deleted stale launch '{launch_name}' ({launch_uuid})")
+            deleted += 1
+        else:
+            LOGGER.error(f"Failed to delete launch '{launch_name}' ({launch_uuid})")
+
+    LOGGER.info(f"Deleted {deleted}/{len(stale)} stale launch(es)")
+    return 0 if deleted > 0 else 1

--- a/src/enge/reportportal/utils.py
+++ b/src/enge/reportportal/utils.py
@@ -867,3 +867,36 @@ def show_dryrun_delete_logs(
     )
     print(f"{FormatText.BLUE}{'=' * 60}{FormatText.END}")
     print()
+
+
+def show_dryrun_delete_stale(launches: List[Dict[str, Any]]) -> None:
+    """Display stale launches that would be deleted in dry-run mode."""
+    from enge.utils import FormatText
+
+    print()
+    print(f"{FormatText.BLUE}{'=' * 60}{FormatText.END}")
+    print(
+        f"{FormatText.BLUE}DRY RUN - Stale Launch Deletion Preview" f"{FormatText.END}"
+    )
+    print(f"{FormatText.BLUE}{'=' * 60}{FormatText.END}")
+    print()
+    print(
+        f"{FormatText.BOLD}Stale launches "
+        f"(stopped/interrupted, no items):{FormatText.END} {len(launches)}"
+    )
+    print()
+
+    for launch in launches:
+        name = launch.get("name", "Unknown")
+        uuid = launch.get("uuid", launch.get("id", "?"))
+        lid = launch.get("id", "?")
+        print(f"  - {name} (id={lid}, uuid={uuid})")
+    print()
+
+    word = "launch" if len(launches) == 1 else "launches"
+    print(
+        f"{FormatText.GREEN}Would delete "
+        f"{len(launches)} stale {word}{FormatText.END}"
+    )
+    print(f"{FormatText.BLUE}{'=' * 60}{FormatText.END}")
+    print()

--- a/src/enge/utils/__init__.py
+++ b/src/enge/utils/__init__.py
@@ -4,7 +4,9 @@ Utility functions and classes for enge.
 This module provides common utilities including text formatting and date/time helpers.
 """
 
-from datetime import datetime
+import calendar
+import re
+from datetime import datetime, timedelta
 from typing import Optional
 
 
@@ -113,6 +115,52 @@ class FormatText:
     def info_text(cls, text: str) -> str:
         """Format text as info (blue)."""
         return cls.format_text(text, text_col=cls.BLUE)
+
+
+_RELATIVE_DATE_RE = re.compile(r"^(\d+)([hdwmy])$", re.IGNORECASE)
+
+
+def _subtract_months(dt: datetime, n: int) -> datetime:
+    """Subtract *n* calendar months from *dt*, clamping the day."""
+    month = dt.month - n
+    year = dt.year + (month - 1) // 12
+    month = (month - 1) % 12 + 1
+    day = min(dt.day, calendar.monthrange(year, month)[1])
+    return dt.replace(year=year, month=month, day=day)
+
+
+def parse_date_arg(value: str) -> datetime:
+    """Parse a date CLI argument into a :class:`datetime`.
+
+    Accepts either an absolute date (``YYYY-MM-DD``) or a relative
+    alias that means "N units ago from now":
+
+    - ``h`` — hours  (e.g. ``6h``)
+    - ``d`` — days   (e.g. ``3d``)
+    - ``w`` — weeks  (e.g. ``2w``)
+    - ``m`` — months (e.g. ``1m``)
+    - ``y`` — years  (e.g. ``1y``)
+
+    Raises:
+        ValueError: If *value* matches neither format.
+    """
+    m = _RELATIVE_DATE_RE.match(value)
+    if m:
+        amount = int(m.group(1))
+        unit = m.group(2).lower()
+        now = datetime.now()
+        if unit == "h":
+            return now - timedelta(hours=amount)
+        if unit == "d":
+            return now - timedelta(days=amount)
+        if unit == "w":
+            return now - timedelta(weeks=amount)
+        if unit == "m":
+            return _subtract_months(now, amount)
+        # unit == "y"
+        return _subtract_months(now, amount * 12)
+
+    return datetime.strptime(value, "%Y-%m-%d")
 
 
 def get_datetime() -> str:

--- a/src/enge/utils/arg_parser.py
+++ b/src/enge/utils/arg_parser.py
@@ -76,6 +76,22 @@ def _add_dryrun_arg(
     )
 
 
+def _add_date_filter_args(parser: argparse.ArgumentParser) -> None:
+    """Add ``--since`` and ``--until`` date filter arguments to a parser."""
+    parser.add_argument(
+        "--since",
+        metavar="DATE",
+        help="Only consider items from on or after DATE "
+        "(YYYY-MM-DD or relative: 6h, 3d, 2w, 1m, 1y).",
+    )
+    parser.add_argument(
+        "--until",
+        metavar="DATE",
+        help="Only consider items from on or before DATE "
+        "(YYYY-MM-DD or relative: 6h, 3d, 2w, 1m, 1y).",
+    )
+
+
 def _add_tagging_args(parser: argparse.ArgumentParser) -> None:
     """
     Add common tagging arguments (--set-tag, --auto-tag) to a parser.
@@ -408,6 +424,9 @@ def get_arguments(args: Optional[list] = None) -> argparse.Namespace:
         help="Display tables formatted for JIRA comments.",
     )
 
+    # Date filters (effective with --get-tag, filters by archive filename timestamp)
+    _add_date_filter_args(report)
+
     # ==================== RERUN SUBCOMMAND ====================
     rerun = subparsers.add_parser(
         "rerun",
@@ -465,6 +484,12 @@ def get_arguments(args: Optional[list] = None) -> argparse.Namespace:
         "Uses the report module to find the matching launch via TMT context.",
     )
 
+    rp_action.add_argument(
+        "--delete-stale",
+        action="store_true",
+        help="Delete stale launches — stopped/interrupted launches with no test items.",
+    )
+
     # Log enrichment (can be combined with --finish to enrich then finish)
     reportportal.add_argument(
         "--enrich-logs",
@@ -487,6 +512,9 @@ def get_arguments(args: Optional[list] = None) -> argparse.Namespace:
         "With --finish --enrich-logs: enriches then finishes IN_PROGRESS launches. "
         "Launches already enriched by enge are skipped automatically.",
     )
+
+    # Date filters (effective with --all-launches and --delete-stale)
+    _add_date_filter_args(reportportal)
 
     # Input sources (for --finish and --enrich-logs actions)
     _add_input_source_args(reportportal)


### PR DESCRIPTION
…and report

- Add --delete-stale to remove stopped/interrupted launches with no test items
- Add --since/--until flags with relative aliases (6h, 3d, 2w, 1m, 1y) and absolute dates (YYYY-MM-DD) for filtering launches and archived task files
- Generalize get_all_in_progress_launches into get_all_launches(status) to reduce duplication across all-launches operations