### PR TITLE
Fix data-loss: latest-jobs file wiped on every record_task_ids() call

### DIFF
--- a/src/enge/dispatch/__main__.py
+++ b/src/enge/dispatch/__main__.py
@@ -29,7 +29,7 @@ from typing import List, Dict, Any, Optional
 from enge.utils.globals import ARTIFACT_MAPPING
 from enge.utils.console import console
 from enge.utils.opt_manager import parsed_opts
-from .tf_send_request import SubmitTest
+from .tf_send_request import SubmitTest, clear_latest_jobs_file
 from enge.utils.reportportal_helper import create_launch as rp_create_launch
 from enge.utils.globals import RP_COMPATIBLE_EVENT
 from .set_flow import expand_set_requests, process_request_spec
@@ -457,6 +457,8 @@ def main() -> int:
         artifact_type = _determine_artifact_type()
 
         dispatch_results: List[Dict[str, Any]] = []
+        if not getattr(parsed_opts.cli_args, "dryrun", False):
+            clear_latest_jobs_file()
 
         # Check if we have individual test sets (new approach)
         if (

--- a/src/enge/dispatch/tf_send_request.py
+++ b/src/enge/dispatch/tf_send_request.py
@@ -21,6 +21,21 @@ from enge.utils.globals import (
 LOGGER = logging.getLogger(__name__)
 
 
+def clear_latest_jobs_file():
+    """Remove the latest-jobs file at the start of a dispatch run.
+
+    Called once per enge invocation before any record_task_ids() calls so that
+    a fresh run always starts with an empty file rather than appending to
+    leftovers from a previous run.
+    """
+    path = parsed_opts.archive_tasks_latest
+    if path:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+
+
 class SubmitTest:
     def __init__(
         self,
@@ -277,8 +292,6 @@ class SubmitTest:
             self.archive_tasks_file = ".".join([self.archive_tasks_file] + sorted_tags)
 
         def _handle_archive_files():
-            if self.latest_tasks_file and os.path.exists(self.latest_tasks_file):
-                os.unlink(self.latest_tasks_file)
             if self.archive_tasks_default_path and not os.path.exists(
                 self.archive_tasks_default_path
             ):

--- a/src/enge/rerun/__main__.py
+++ b/src/enge/rerun/__main__.py
@@ -11,7 +11,7 @@ from rich.markup import escape
 from rich import box
 
 from enge.dispatch.pin_compose import repin_compose
-from enge.dispatch.tf_send_request import SubmitTest
+from enge.dispatch.tf_send_request import SubmitTest, clear_latest_jobs_file
 from enge.report.__main__ import parse_tasks_with_map, parse_request_xunit
 from enge.utils.opt_manager import parsed_opts
 from enge.utils.globals import REQUEST_TIMEOUT_DEFAULT, RP_COMPATIBLE_EVENT
@@ -793,6 +793,8 @@ def main():
 
     is_dryrun = getattr(parsed_opts.cli_args, "dryrun", False)
 
+    if not getattr(parsed_opts.cli_args, "dryrun", False):
+        clear_latest_jobs_file()
     # Send each rerun request using the filtered original payload
     for i, payload in enumerate(jobs.rerun_payloads):
         # Add rerun_of to tmt.context

--- a/tests/test_record_task_ids.py
+++ b/tests/test_record_task_ids.py
@@ -1,0 +1,123 @@
+"""Regression tests for the latest-jobs file clear-once-per-run fix.
+
+Before the fix, SubmitTest.record_task_ids() called os.unlink() on the latest
+file on every invocation, so in a multi-request dispatch only the last task ID
+survived.  After the fix, clear_latest_jobs_file() is called once before the
+dispatch loop and record_task_ids() only appends.  Dry-run invocations must
+never clear the file.
+"""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from enge.dispatch import tf_send_request
+from enge.dispatch.tf_send_request import SubmitTest, clear_latest_jobs_file
+
+
+def _make_opts(archive_dir, latest_path):
+    return SimpleNamespace(
+        archive_tasks_latest=latest_path,
+        archive_tasks_default=archive_dir,
+        testing_farm_endpoint=SimpleNamespace(
+            log_artifact_baseurl="http://logs.example.com",
+            api_endpoint_url="http://api.example.com",
+        ),
+        cli_args=SimpleNamespace(
+            dryrun=False,
+            action="test",
+            wait=False,
+            set_tag=None,
+            auto_tag=False,
+        ),
+    )
+
+
+class TestRecordTaskIds(unittest.TestCase):
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmpdir.name)
+        self.archive_dir = self.tmp / "archive"
+        self.archive_dir.mkdir()
+        self.latest_path = str(self.tmp / "latest_jobs")
+        self.opts = _make_opts(str(self.archive_dir), self.latest_path)
+        self._patcher = patch.object(tf_send_request, "parsed_opts", self.opts)
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+        self._tmpdir.cleanup()
+
+    def _submit(self, archive_filename="enge_jobs_archive_test"):
+        return SubmitTest(shared_archive_filename=archive_filename)
+
+    def test_all_task_ids_present_in_latest_file(self):
+        """Three record_task_ids calls across separate SubmitTest instances must
+        all appear in the latest file after one clear_latest_jobs_file() call."""
+        clear_latest_jobs_file()
+        ids = ["task-aaa", "task-bbb", "task-ccc"]
+        for task_id in ids:
+            self._submit().record_task_ids(task_id)
+        latest = Path(self.latest_path).read_text().splitlines()
+        self.assertEqual(latest, ids)
+
+    def test_archive_file_also_contains_all_task_ids(self):
+        """Archive file must contain all IDs (unchanged append semantics)."""
+        clear_latest_jobs_file()
+        ids = ["task-111", "task-222", "task-333"]
+        for task_id in ids:
+            self._submit().record_task_ids(task_id)
+        archive_files = list(self.archive_dir.iterdir())
+        self.assertEqual(len(archive_files), 1)
+        archive_lines = archive_files[0].read_text().splitlines()
+        self.assertEqual(archive_lines, ids)
+
+    def test_second_run_does_not_contain_first_run_ids(self):
+        """Two separate runs (two clear calls) must produce independent latest files."""
+        # First run: two requests
+        clear_latest_jobs_file()
+        for task_id in ["run1-aaa", "run1-bbb"]:
+            self._submit("enge_jobs_archive_run1").record_task_ids(task_id)
+
+        # Second run: one request
+        clear_latest_jobs_file()
+        self._submit("enge_jobs_archive_run2").record_task_ids("run2-zzz")
+
+        latest = Path(self.latest_path).read_text().splitlines()
+        self.assertEqual(latest, ["run2-zzz"])
+        self.assertNotIn("run1-aaa", latest)
+        self.assertNotIn("run1-bbb", latest)
+
+    def test_clear_is_noop_when_file_absent(self):
+        """clear_latest_jobs_file() must not raise when the file does not exist."""
+        self.assertFalse(Path(self.latest_path).exists())
+        clear_latest_jobs_file()  # must not raise
+
+    def test_dryrun_does_not_clear_latest_file(self):
+        """When dryrun=True the latest file must be left untouched."""
+        sentinel = "previous-run-id"
+        Path(self.latest_path).write_text(f"{sentinel}\n")
+
+        self.opts.cli_args.dryrun = True
+        if not getattr(self.opts.cli_args, "dryrun", False):
+            clear_latest_jobs_file()
+
+        self.assertTrue(Path(self.latest_path).exists())
+        self.assertIn(sentinel, Path(self.latest_path).read_text())
+
+    def test_non_dryrun_clears_latest_file(self):
+        """When dryrun=False the latest file must be removed by the guard."""
+        Path(self.latest_path).write_text("old-run-id\n")
+
+        self.opts.cli_args.dryrun = False
+        if not getattr(self.opts.cli_args, "dryrun", False):
+            clear_latest_jobs_file()
+
+        self.assertFalse(Path(self.latest_path).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
record_task_ids() called os.unlink() on the latest file before each append, so in a multi-request dispatch only the last task ID survived. A bare `enge report` therefore silently reported only the final request of a matrix run.

Fix: remove the os.unlink() from _handle_archive_files() and introduce clear_latest_jobs_file(), a standalone helper that deletes the file (ignoring FileNotFoundError) exactly once. It is called in the dispatch and rerun entry points just before their respective dispatch loops so every new invocation starts fresh without relying on hidden per-instance state. Archive-file append semantics are unchanged.

Fixes: dispatching N requests now writes exactly N lines to the latest file; the archive file is unaffected.