### PR TITLE
fix: config-resolution hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `src/__init__.py` (src directory must not be a Python package)
 
 ### Fixed
+- Empty-string config values (`""`) are now treated as absent at every layer; the next
+  precedence layer (default config) is inherited instead of being masked. A WARNING is
+  logged per key where this substitution occurs. Previously `""` was treated as an
+  explicit override, hiding the default silently.
+- Tier selection now falls back to `[tests].tiers` (list) from the merged config when
+  no tier is given via `-T` or per-set `tiers`. Previously the fallback accidentally
+  picked up `[tests].tier` (the filter-definition mapping table), causing a `KeyError: 0`
+  crash. The default config now ships `tiers = ['tier3']` as a catch-all.
+- Missing or misconfigured Testing Farm endpoint URLs now raise a `ConfigurationError`
+  (exit code 99) naming the missing key(s) instead of a bare `ValueError` (exit code 1).
+- Validation errors that collect multiple detail lines now include those details in the
+  exception message instead of only in the CRITICAL log. The full log output is unchanged.
 - `-o json` mode no longer silences log output; logs go to stderr independently
 - `-o json --dry-run` produces a single JSON document instead of interleaved payloads
 - GitLab output format uses triple-backtick fences instead of Jira `{noformat}` tags

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,3 +134,8 @@ module → unify reportportal task/all-launches pipelines under subcommands →
 manifest-based state store (XDG paths, retires filename tags) →
 config-as-data (RHSM flag presets, source→target mapping table replacing the
 `minor - 6` formula, RP event list).
+
+Planned breaking config change (deferred, coordinate with users):
+rename `[tests].tier` (filter-definition table) to `[tests].tier_definitions` to
+eliminate the naming collision with the `[tests].tiers` selection list; requires a
+migration guide and a config-schema version bump.

--- a/README.md
+++ b/README.md
@@ -820,22 +820,11 @@ enge report --get-tag smoke --since 12h
 
 ## Troubleshooting configuration and validation
 
-#### Empty string overrides vs. inheriting defaults
-
-enge merges your user configuration over the defaults. If you set a key to an empty string (e.g., `[tests].git_ref = ''`), that explicit value overrides the default and is treated as missing by validators. This can trigger errors like:
-
-```
-CRITICAL | Operational defaults validation failed:
-CRITICAL |   - Missing operational default: [tests].git_ref
-CRITICAL | This indicates a problem with the default configuration file.
-CRITICAL | Configuration error: Operational defaults validation failed
-```
-
-To inherit the default value shipped in `enge_default_config.toml`, **omit the key entirely** in your user `enge.toml` (or comment it out). Only set a value when you want to intentionally override the default.
-
-Notes:
-- Set-level values (under `[tests.set.<name>]`) are evaluated when using `--set`. Top-level operational defaults such as `[tests].git_ref` are still validated; leaving them as empty strings will fail validation.
-- If you rely exclusively on set-level configuration, remove or comment out the top-level empty keys to avoid overriding defaults.
+**Empty string and None are treated as unset.** If your `enge.toml` sets a key
+to `''` (empty string) or `null`, enge inherits the default from
+`enge_default_config.toml` for that key.  A warning is logged so you know
+the override was ignored.  Validators only fire when *no layer* provides a
+non-empty value.
 
 Corresponding return code is set based on the results with following logic:
  * 0 - The results are complete for each request and all are pass

--- a/src/enge/utils/config_parser.py
+++ b/src/enge/utils/config_parser.py
@@ -119,7 +119,10 @@ def merge_configs(default: Dict[str, Any], user: Dict[str, Any]) -> Dict[str, An
     Merge user configuration with default configuration.
 
     User values take precedence over defaults. Nested dictionaries are
-    merged recursively.
+    merged recursively.  Empty string ("") and None from the user config are
+    treated as absent: the default value is inherited when a real default
+    exists.  This lets config authors express "intentionally empty" only when
+    the default is also empty.
 
     Args:
         default: Default configuration dictionary
@@ -134,11 +137,37 @@ def merge_configs(default: Dict[str, Any], user: Dict[str, Any]) -> Dict[str, An
         if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
             # Recursively merge nested dictionaries
             merged[key] = merge_configs(merged[key], value)
+        elif value in (None, ""):
+            # Treat None/"" as absent; keep the default if it is non-empty.
+            existing = merged.get(key)
+            if existing in (None, ""):
+                merged[key] = value  # no real default to inherit
         else:
             # User value overwrites default
             merged[key] = value
 
     return merged
+
+
+def _warn_empty_user_values(
+    user: Dict[str, Any], merged: Dict[str, Any], path: str, section: str = ""
+) -> None:
+    """Log one WARNING per key where the user set "" or None but a real default
+    was inherited.  Called from load_config after the merge, where the file
+    path is known."""
+    for key, value in user.items():
+        full_key = f"[{section}].{key}" if section else key
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            _warn_empty_user_values(value, merged[key], path, section=key)
+        elif value in (None, ""):
+            inherited = merged.get(key)
+            if inherited not in (None, ""):
+                LOGGER.warning(
+                    "%s is empty in %s — inheriting default %r",
+                    full_key,
+                    path,
+                    inherited,
+                )
 
 
 def load_config(paths: Union[List[str], List[Path]]) -> Dict[str, Any]:
@@ -232,6 +261,11 @@ def load_config(paths: Union[List[str], List[Path]]) -> Dict[str, Any]:
 
     # Merge user config with defaults
     merged_config = merge_configs(default_config, user_config)
+
+    # Warn about keys where the user explicitly wrote "" or None but a real
+    # default was inherited.  One warning per key helps authors understand the rule.
+    loaded_path = next((str(p) for p in expanded_paths if p.exists()), "<unknown>")
+    _warn_empty_user_values(user_config, merged_config, loaded_path)
 
     LOGGER.debug("Configuration loaded and merged with defaults")
     return merged_config

--- a/src/enge/utils/enge_default_config.toml
+++ b/src/enge/utils/enge_default_config.toml
@@ -104,6 +104,7 @@ project = '' # REQUIRED - for correct functioning of the 'enge rp' commands and 
 [tests]
 git_url = '' # REQUIRED: URL to tests metadata repository
 git_ref = 'main' # REQUIRED: Git ref (branch/tag/commit) to checkout test suite from
+tiers = ['tier3'] # default catch-all (tier3 = 'tag:tier[0123]'); override via -T or per set
 
 
 # ---------------------------------------------------------------------------

--- a/src/enge/utils/opt_manager.py
+++ b/src/enge/utils/opt_manager.py
@@ -36,9 +36,14 @@ logger = logging.getLogger(__name__)
 
 class TestingFarmEndpoint:
     def __init__(self, api_endpoint_url, log_artifact_baseurl):
-        if not api_endpoint_url or not log_artifact_baseurl:
-            raise ValueError(
-                "Both api_endpoint_url and log_artifact_baseurl are required in [testing_farm] config."
+        missing = []
+        if not api_endpoint_url:
+            missing.append("[testing_farm].api_endpoint_url")
+        if not log_artifact_baseurl:
+            missing.append("[testing_farm].log_artifact_baseurl")
+        if missing:
+            raise ConfigurationError(
+                f"Required Testing Farm URL(s) not configured: {', '.join(missing)}"
             )
         self.api_endpoint_url = api_endpoint_url
         self.log_artifact_baseurl = log_artifact_baseurl
@@ -245,7 +250,7 @@ class ParsedOpts:
                     )
                     try:
                         effective = resolve_effective_values(
-                            self.cli_args, set_cfg, self.config
+                            self.cli_args, set_cfg, self.config, log_fallbacks=False
                         )
                     except Exception:
                         effective = {}
@@ -255,7 +260,9 @@ class ParsedOpts:
                         )
             else:
                 try:
-                    effective = resolve_effective_values(self.cli_args, {}, self.config)
+                    effective = resolve_effective_values(
+                        self.cli_args, {}, self.config, log_fallbacks=False
+                    )
                 except Exception:
                     effective = {}
                 if not effective.get("git_ref"):
@@ -311,9 +318,10 @@ class ParsedOpts:
                 continue
 
             for key in required_keys:
-                # Generic check for other operational defaults
+                # Only check for None: "" is treated as absent at merge time
+                # so it should never reach the validator from a real config load.
                 value = section.get(key)
-                if value is None or value == "":  # Check for None or empty string
+                if value is None:
                     errors.append(
                         f"Missing operational default: [{section_name}].{key}"
                     )
@@ -325,7 +333,10 @@ class ParsedOpts:
             logger.critical(
                 "This indicates a problem with the default configuration file."
             )
-            raise ConfigurationError("Operational defaults validation failed")
+            detail = "\n".join(f"  - {e}" for e in errors)
+            raise ConfigurationError(
+                f"Operational defaults validation failed:\n{detail}"
+            )
 
     def _validate_required_config(self):
         """Validate required configuration for operations that need it."""
@@ -470,7 +481,8 @@ class ParsedOpts:
                 logger.critical("Required configuration validation failed:")
                 for error in errors:
                     logger.critical(f"  - {error}")
-                raise ConfigurationError("Required configuration missing")
+                detail = "\n".join(f"  - {e}" for e in errors)
+                raise ConfigurationError(f"Required configuration missing:\n{detail}")
 
         # ReportPortal configuration required for the 'reportportal' subcommand
         # Only require token here; URL/project may be provided elsewhere and are optional overrides in config
@@ -529,6 +541,33 @@ class ParsedOpts:
         ):
             errors.append("[tests].context must be a dictionary")
 
+        # Shape validation: [tests].tiers must be a list of strings;
+        # [tests].tier must be a table (dict).  A mixup between the two keys
+        # must fail loudly — never produce a KeyError: 0 at dispatch time.
+        if tests_section:
+            config_tiers = tests_section.get("tiers")
+            config_tier = tests_section.get("tier")
+            shape_error = False
+            if config_tiers is not None and not isinstance(config_tiers, list):
+                errors.append(
+                    "[tests].tiers must be a list of strings (tier selection); "
+                    "[tests].tier must be a table (filter definitions). "
+                    f"Got [tests].tiers={type(config_tiers).__name__!r}."
+                )
+                shape_error = True
+            if config_tier is not None and not isinstance(config_tier, dict):
+                errors.append(
+                    "[tests].tier must be a table (filter definitions); "
+                    "[tests].tiers must be a list of strings (tier selection). "
+                    f"Got [tests].tier={type(config_tier).__name__!r}."
+                )
+                shape_error = True
+            if not shape_error and isinstance(config_tiers, list):
+                if not all(isinstance(t, str) for t in config_tiers):
+                    errors.append(
+                        "[tests].tiers must contain only strings (tier names)."
+                    )
+
         # Validate architectures with priority: CLI > Set > Config
         # - When using sets, per-set architectures are validated later during resolution
         # - When not using sets, require architectures from CLI or config
@@ -574,7 +613,8 @@ class ParsedOpts:
             logger.critical("Static configuration validation failed:")
             for error in errors:
                 logger.critical(f"  - {error}")
-            raise ConfigurationError("Static configuration invalid")
+            detail = "\n".join(f"  - {e}" for e in errors)
+            raise ConfigurationError(f"Static configuration invalid:\n{detail}")
 
     def _validate_cli_arguments(self):
         """Validate CLI argument combinations and requirements."""
@@ -680,7 +720,8 @@ class ParsedOpts:
             logger.critical("Option dependency validation failed:")
             for error in errors:
                 logger.critical(f"  - {error}")
-            raise ValidationError("Option dependency validation failed")
+            detail = "\n".join(f"  - {e}" for e in errors)
+            raise ValidationError(f"Option dependency validation failed:\n{detail}")
 
     def _validate_test_sets_internal(self, set_names: List[str]) -> bool:
         """Validate that specified test sets exist and are properly configured."""

--- a/src/enge/utils/source_target_parser.py
+++ b/src/enge/utils/source_target_parser.py
@@ -13,7 +13,7 @@ from logging import getLogger
 from enge.utils.globals import TMT_PLUGIN_REPORT_REPORTPORTAL_PREFIX
 from enge.utils.globals import RP_COMPATIBLE_EVENT
 from enge.utils.globals import VERBOSE
-from enge.utils.errors import ValidationError
+from enge.utils.errors import ConfigurationError, ValidationError
 
 LOGGER = getLogger(__name__)
 
@@ -811,7 +811,10 @@ def merge_test_set_config(
 
 
 def resolve_effective_values(
-    cli_args: Any, set_config: Dict[str, Any], config: Dict[str, Any]
+    cli_args: Any,
+    set_config: Dict[str, Any],
+    config: Dict[str, Any],
+    log_fallbacks: bool = True,
 ) -> Dict[str, Any]:
     """
     Resolve effective values from CLI args, test sets, and config.
@@ -878,18 +881,28 @@ def resolve_effective_values(
             "tests", {}
         ).get("parallel_limit")
 
-    # Resolve tiers (CLI > Set > Config)
-    # Handle both singular "tier" and plural "tiers" keys
+    # Resolve tier SELECTION (CLI > set > [tests].tiers).
+    # [tests].tier is the filter-definition mapping — never used as a selection source.
     cli_tier = getattr(cli_args, "tier", None)
     set_tiers = set_config.get("tiers")
     config_tiers = config.get("tests", {}).get("tiers")
-    config_tier = config.get("tests", {}).get("tier")
 
-    # Normalize config_tier to list if it's a string
-    if config_tier and isinstance(config_tier, str):
-        config_tier = [config_tier]
-
-    resolved["tiers"] = cli_tier or set_tiers or config_tiers or config_tier
+    if cli_tier:
+        resolved["tiers"] = cli_tier
+    elif set_tiers:
+        resolved["tiers"] = set_tiers
+    elif config_tiers:
+        if log_fallbacks:
+            LOGGER.info(
+                "tiers not specified via CLI or set, using default from [tests]: %s",
+                config_tiers,
+            )
+        resolved["tiers"] = config_tiers
+    else:
+        raise ConfigurationError(
+            "No tiers resolved from CLI, set, or [tests].tiers"
+            " — check the default configuration"
+        )
 
     # Resolve event (CLI > Set)
     resolved["event"] = getattr(cli_args, "event", None) or set_config.get("event")

--- a/tests/test_opt_manager.py
+++ b/tests/test_opt_manager.py
@@ -118,15 +118,16 @@ class TestMergeConfigs(unittest.TestCase):
         self.assertEqual(merged["outer"]["b"], 99)  # user wins
         self.assertEqual(merged["outer"]["c"], 3)  # user-only key added
 
-    def test_user_empty_string_replaces_default(self):
-        # CHARACTERIZATION: empty string from user config overwrites a real
-        # default.  The caller is responsible for treating "" as "missing."
+    def test_user_empty_string_inherits_default(self):
+        # Pin flipped: "" from user config is now treated as absent, so the
+        # default value is inherited.  Validators only check for None.
         merged = merge_configs({"key": "default-value"}, {"key": ""})
-        self.assertEqual(merged["key"], "")
+        self.assertEqual(merged["key"], "default-value")
 
-    def test_user_none_replaces_default(self):
+    def test_user_none_inherits_default(self):
+        # None from user config is also treated as absent; default wins.
         merged = merge_configs({"key": "default-value"}, {"key": None})
-        self.assertIsNone(merged["key"])
+        self.assertEqual(merged["key"], "default-value")
 
     def test_user_only_key_added_to_merged(self):
         merged = merge_configs({"a": 1}, {"b": 2})
@@ -155,6 +156,8 @@ class TestResolveEffectiveValues(unittest.TestCase):
     """Priority chain: CLI arg wins, then test-set config, then top-level config."""
 
     def _cli(self, **kwargs):
+        # tier defaults to ["tier0"] so tests that focus on other fields don't
+        # trigger ConfigurationError from the "no tiers resolved" guard.
         defaults = dict(
             source=None,
             target=None,
@@ -163,7 +166,7 @@ class TestResolveEffectiveValues(unittest.TestCase):
             git_ref=None,
             git_url=None,
             parallel_limit=None,
-            tier=None,
+            tier=["tier0"],
             event=None,
             plan=None,
         )
@@ -195,14 +198,37 @@ class TestResolveEffectiveValues(unittest.TestCase):
         self.assertEqual(result["source"], "cfg-src")
 
     def test_empty_string_cli_falls_through_to_set(self):
-        # CHARACTERIZATION: "" is falsy in the `or` chain, so the set value
-        # wins.  There is no way to "clear" a value by passing --source "".
+        # Pin #3 resolved (no longer surprising): "" is treated as absent and
+        # the set value wins, per the explicit unset rule.
         result = resolve_effective_values(
             self._cli(source=""),
             {"source": "set-src"},
             {},
         )
         self.assertEqual(result["source"], "set-src")
+
+    def test_empty_string_set_falls_through_to_config(self):
+        result = resolve_effective_values(
+            self._cli(source=None),
+            {"source": ""},
+            {"tests": {"source": "cfg-src"}},
+        )
+        self.assertEqual(result["source"], "cfg-src")
+
+    def test_none_falls_through_identically_to_empty_string(self):
+        # None and "" behave identically at every layer.
+        result_none = resolve_effective_values(
+            self._cli(source=None),
+            {"source": None},
+            {"tests": {"source": "cfg-src"}},
+        )
+        result_empty = resolve_effective_values(
+            self._cli(source=""),
+            {"source": ""},
+            {"tests": {"source": "cfg-src"}},
+        )
+        self.assertEqual(result_none["source"], "cfg-src")
+        self.assertEqual(result_empty["source"], "cfg-src")
 
     def test_cli_plans_override_set_and_config(self):
         result = resolve_effective_values(
@@ -305,26 +331,36 @@ class TestOperationalDefaults(unittest.TestCase):
         po._validate_operational_defaults()  # must not raise
 
     def test_missing_common_section_raises_configuration_error(self):
-        # CHARACTERIZATION: the exception message is the summary ("Operational
-        # defaults validation failed"); the per-section detail ("Missing
-        # operational section: [common]") is only in the CRITICAL log output.
+        # Pin #4 flipped: detail lines are now included in the exception
+        # message itself (joined), not only in CRITICAL log output.
         cfg = copy.deepcopy(MINIMAL_CONFIG)
         del cfg["common"]
         po = _make_partial_opts(config=cfg)
         with self.assertLogs("enge.utils.opt_manager", level="CRITICAL") as log:
-            with self.assertRaises(ConfigurationError):
+            with self.assertRaises(ConfigurationError) as ctx:
                 po._validate_operational_defaults()
         self.assertTrue(any("common" in m.lower() for m in log.output))
+        self.assertIn("common", str(ctx.exception).lower())
 
-    def test_empty_string_key_raises_configuration_error(self):
-        # CHARACTERIZATION: empty string is treated the same as None by
-        # _validate_operational_defaults (check: value is None or value == "").
+    def test_empty_string_key_no_longer_raises_configuration_error(self):
+        # Pin #6 flipped: "" is now treated as absent at merge time so the
+        # default is inherited before the validator runs.  The validator only
+        # checks for None; "" reaching it directly (bypassing merge) no longer
+        # triggers an error.
         cfg = copy.deepcopy(MINIMAL_CONFIG)
         cfg["common"]["archive_tasks_latest"] = ""
+        po = _make_partial_opts(config=cfg)
+        po._validate_operational_defaults()  # must not raise
+
+    def test_none_key_still_raises_configuration_error(self):
+        # When no layer provides a value (None), the validator fires.
+        cfg = copy.deepcopy(MINIMAL_CONFIG)
+        cfg["common"]["archive_tasks_latest"] = None
         po = _make_partial_opts(config=cfg)
         with self.assertRaises(ConfigurationError) as ctx:
             po._validate_operational_defaults()
         self.assertIn("Operational defaults", str(ctx.exception))
+        self.assertIn("archive_tasks_latest", str(ctx.exception))
 
     def test_none_key_raises_configuration_error(self):
         cfg = copy.deepcopy(MINIMAL_CONFIG)
@@ -364,6 +400,9 @@ class TestRequiredConfig(unittest.TestCase):
         po._validate_required_config()  # must not raise
 
     def test_test_action_empty_api_key_raises(self):
+        # Pin #7: api_key has no default, so "" is "no value provided" and the
+        # validator fires.  _validate_required_config uses `not value`, which
+        # treats "" the same as None — intentional (empty key is unusable).
         cfg = copy.deepcopy(MINIMAL_CONFIG)
         cfg["testing_farm"]["api_key"] = ""
         po = _make_partial_opts(
@@ -460,17 +499,18 @@ class TestStaticConfiguration(unittest.TestCase):
         po._validate_static_configuration()  # must not raise
 
     def test_test_action_without_cli_or_config_arch_raises(self):
-        # CHARACTERIZATION: exception summary is "Static configuration invalid";
-        # the per-field detail ("No architectures configured...") appears only
-        # in the CRITICAL log output.
+        # Pin #4 flipped: the per-field detail ("No architectures configured...")
+        # is now included in the exception message itself, in addition to the
+        # CRITICAL log output which is unchanged.
         cfg = copy.deepcopy(MINIMAL_CONFIG)
         # No architectures anywhere; no sets
         cli = get_arguments(args=["test", "-s", "9.7", "-T", "tier0"])  # no --arch
         po = _make_partial_opts(config=cfg, cli_args=cli)
         with self.assertLogs("enge.utils.opt_manager", level="CRITICAL") as log:
-            with self.assertRaises(ConfigurationError):
+            with self.assertRaises(ConfigurationError) as ctx:
                 po._validate_static_configuration()
         self.assertTrue(any("architectures" in m.lower() for m in log.output))
+        self.assertIn("architectures", str(ctx.exception).lower())
 
     def test_test_action_with_sets_bypasses_arch_requirement(self):
         # When using --set, per-set architectures are expected; no top-level arch needed.
@@ -707,18 +747,18 @@ class TestFullConstructorReport(unittest.TestCase):
         )
 
     @patch("enge.utils.opt_manager.load_config")
-    def test_empty_endpoint_url_raises_value_error_not_configuration_error(
-        self, mock_load
-    ):
-        # CHARACTERIZATION: TestingFarmEndpoint is constructed unconditionally,
-        # even for non-test actions.  When api_endpoint_url is empty it raises
-        # ValueError (not ConfigurationError), bypassing the normal error path.
-        # _validate_required_config does NOT check endpoint URLs for 'report'.
+    def test_empty_endpoint_url_raises_configuration_error(self, mock_load):
+        # Pin #1 flipped: TestingFarmEndpoint now raises ConfigurationError
+        # (naming the config key), which maps to EXIT_CONFIG_ERROR (99) via
+        # __main__ error handling — not exit 1 as before.
+        # The timing (constructed unconditionally) and _validate_required_config
+        # scope are unchanged — both are AppContext-refactor territory.
         cfg = copy.deepcopy(MINIMAL_CONFIG)
         cfg["testing_farm"]["api_endpoint_url"] = ""
         mock_load.return_value = cfg
-        with self.assertRaises(ValueError):  # ValueError, not ConfigurationError
+        with self.assertRaises(ConfigurationError) as ctx:
             ParsedOpts(cli_args=get_arguments(args=["report"]))
+        self.assertIn("api_endpoint_url", str(ctx.exception))
 
     @patch("enge.utils.opt_manager.load_config")
     def test_validate_opts_propagates_configuration_error(self, mock_load):
@@ -740,11 +780,14 @@ class TestFullConstructorReport(unittest.TestCase):
 class TestTestingFarmEndpoint(unittest.TestCase):
 
     def test_both_urls_required(self):
-        with self.assertRaises(ValueError):
+        # Pin #1 flipped: ConfigurationError now (was ValueError).
+        with self.assertRaises(ConfigurationError) as ctx:
             TestingFarmEndpoint("", "https://logs.example.tf")
-        with self.assertRaises(ValueError):
+        self.assertIn("api_endpoint_url", str(ctx.exception))
+        with self.assertRaises(ConfigurationError) as ctx:
             TestingFarmEndpoint("https://api.example.tf", "")
-        with self.assertRaises(ValueError):
+        self.assertIn("log_artifact_baseurl", str(ctx.exception))
+        with self.assertRaises(ConfigurationError):
             TestingFarmEndpoint("", "")
 
     def test_both_urls_provided_succeeds(self):

--- a/tests/test_opt_manager_validation.py
+++ b/tests/test_opt_manager_validation.py
@@ -23,7 +23,7 @@ import copy
 import unittest
 from unittest.mock import patch
 
-from enge.utils.errors import ValidationError
+from enge.utils.errors import ConfigurationError, ValidationError
 from enge.utils.opt_manager import ParsedOpts
 from enge.utils.arg_parser import get_arguments
 
@@ -55,6 +55,7 @@ MINIMAL_CONFIG = {
         "tier": {
             "tier0": "tag:tier[0]",
             "tier1": "tag:tier[01]",
+            "tier3": "tag:tier[0123]",
         },
     },
     "copr_api": {
@@ -72,19 +73,16 @@ MINIMAL_CONFIG = {
 # Config with two test sets that use CentOS-Stream-9 as source.
 # CentOS-Stream-N is parsed without any pin_compose network call.
 #
-# NOTE: "tier" is deliberately excluded from the tests section.
-# resolve_effective_values() resolves tiers as:
-#   cli_tier or set_tiers or config_tiers or config_tier
-# When all are None/empty, it falls back to config_tier — which for a real
-# config is the tier mapping dict {"tier0": "tag:tier[0]", ...}.
-# That dict then reaches _initialize_test_attributes as effective_tiers and
-# causes `KeyError: 0` at `first_tier = self.effective_tiers[0]`.
-# Excluding "tier" here avoids that bug so tests can reach the happy path.
+# [tests].tiers = ['tier3'] mirrors the default config fallback added in
+# fix/config-resolution-hardening.  Including it here avoids the need to
+# patch the default-config loader in every full-constructor test.
 SETS_CONFIG = {
     **copy.deepcopy(MINIMAL_CONFIG),
     "tests": {
         "git_url": MINIMAL_CONFIG["tests"]["git_url"],
         "git_ref": MINIMAL_CONFIG["tests"]["git_ref"],
+        "tier": MINIMAL_CONFIG["tests"]["tier"],
+        "tiers": ["tier3"],
         "set": {
             "alpha-set": {
                 "source": "CentOS-Stream-9",
@@ -243,18 +241,19 @@ class TestOptionDependencies(unittest.TestCase):
         self.assertIn("Option dependency", str(ctx.exception))
 
     def test_unknown_tier_raises_with_available_tiers_listed(self):
-        # CHARACTERIZATION: exception message is "Option dependency validation
-        # failed"; the per-tier detail ("Tier 'tier99' not found. Available:
-        # ['tier0', 'tier1']") appears only in the CRITICAL log output.
+        # Pin #4 flipped: detail lines ("Tier 'tier99' not found. Available:
+        # [...]") are now included in the exception message itself (joined),
+        # in addition to the CRITICAL log output which is unchanged.
         po = _make_partial_opts(
             cli_args=get_arguments(
                 args=["test", "-s", "9.7", "-T", "tier99", "--arch", "x86_64"]
             )
         )
         with self.assertLogs("enge.utils.opt_manager", level="CRITICAL") as log:
-            with self.assertRaises(ValidationError):
+            with self.assertRaises(ValidationError) as ctx:
                 po._validate_option_dependencies()
         self.assertTrue(any("tier99" in m for m in log.output))
+        self.assertIn("tier99", str(ctx.exception))
 
     def test_nonexistent_set_raises_validation_error(self):
         po = _make_partial_opts(
@@ -568,6 +567,137 @@ class TestFullConstructorTestAction(unittest.TestCase):
         cli = get_arguments(args=["test", "-s", "CentOS-Stream-9", "-T", "tier0"])
         po = ParsedOpts(cli_args=cli)
         self.assertEqual(po.parallel_limit, PARALLEL_LIMIT_DEFAULT)
+
+
+# ---------------------------------------------------------------------------
+# 6. Tier resolution hierarchy — set-with-no-tier, CLI override, [tests].tiers
+# ---------------------------------------------------------------------------
+
+
+class TestTierResolution(unittest.TestCase):
+    """Tests for the tier selection hierarchy: CLI > set > [tests].tiers.
+
+    The [tests].tier mapping (filter definitions) must NEVER be used as the
+    selection source; [tests].tiers is the list-typed default.
+    """
+
+    @patch("enge.utils.opt_manager.load_config")
+    def test_set_with_no_tier_resolves_to_tests_tiers_default(self, mock_load):
+        # Pin #10 flipped: set-with-no-tier no longer crashes with KeyError: 0.
+        # It resolves to [tests].tiers from the config (the default catch-all).
+        cfg = copy.deepcopy(SETS_CONFIG)
+        # alpha-set has no 'tiers' key; [tests].tiers = ['tier3'] provides the default.
+        mock_load.return_value = cfg
+        cli = get_arguments(args=["test", "-S", "alpha-set"])
+        po = ParsedOpts(cli_args=cli)
+        ev = po.individual_test_sets[0]["effective_values"]
+        self.assertEqual(ev["tiers"], ["tier3"])
+
+    @patch("enge.utils.opt_manager.load_config")
+    def test_cli_tier_overrides_tests_tiers_default(self, mock_load):
+        cfg = copy.deepcopy(SETS_CONFIG)
+        mock_load.return_value = cfg
+        cli = get_arguments(args=["test", "-S", "alpha-set", "-T", "tier0"])
+        po = ParsedOpts(cli_args=cli)
+        ev = po.individual_test_sets[0]["effective_values"]
+        self.assertEqual(ev["tiers"], ["tier0"])
+
+    @patch("enge.utils.opt_manager.load_config")
+    def test_set_tiers_override_tests_tiers_default(self, mock_load):
+        cfg = copy.deepcopy(SETS_CONFIG)
+        cfg["tests"]["set"]["alpha-set"]["tiers"] = ["tier1"]
+        mock_load.return_value = cfg
+        cli = get_arguments(args=["test", "-S", "alpha-set"])
+        po = ParsedOpts(cli_args=cli)
+        ev = po.individual_test_sets[0]["effective_values"]
+        self.assertEqual(ev["tiers"], ["tier1"])
+
+    @patch("enge.utils.opt_manager.load_config")
+    def test_tests_tier_mapping_not_used_for_tier_selection(self, mock_load):
+        # When [tests].tiers is absent and no CLI/set tier is given,
+        # ConfigurationError is raised rather than silently falling back to
+        # the [tests].tier mapping dict (which would cause KeyError: 0 on
+        # subsequent index access).
+        cfg = copy.deepcopy(SETS_CONFIG)
+        cfg["tests"].pop("tiers", None)
+        mock_load.return_value = cfg
+        cli = get_arguments(args=["test", "-S", "alpha-set"])
+        with self.assertRaises(ConfigurationError):
+            ParsedOpts(cli_args=cli)
+
+    def test_no_tiers_anywhere_raises_configuration_error(self):
+        # Direct unit test: resolve_effective_values raises ConfigurationError
+        # when all three tier sources (CLI, set, [tests].tiers) are absent.
+        from enge.utils.source_target_parser import resolve_effective_values
+
+        cfg = copy.deepcopy(MINIMAL_CONFIG)  # has no [tests].tiers
+        cli = get_arguments(args=["test", "-S", "alpha-set"])
+        with self.assertRaises(ConfigurationError) as ctx:
+            resolve_effective_values(cli, {}, cfg)
+        self.assertIn("tiers", str(ctx.exception).lower())
+
+    @patch("enge.utils.opt_manager.load_config")
+    def test_tier_fallback_log_emitted_exactly_once(self, mock_load):
+        # The INFO fallback message for tiers-from-[tests].tiers must appear
+        # exactly once through the full init path.  The validation pass calls
+        # resolve_effective_values with log_fallbacks=False so the INFO line
+        # is suppressed there and only fires on the real init resolution.
+        cfg = copy.deepcopy(SETS_CONFIG)
+        mock_load.return_value = cfg
+        cli = get_arguments(args=["test", "-S", "alpha-set"])
+        with self.assertLogs("enge.utils.source_target_parser", level="INFO") as log:
+            ParsedOpts(cli_args=cli)
+        fallback_msgs = [m for m in log.output if "using default from [tests]" in m]
+        self.assertEqual(len(fallback_msgs), 1)
+
+    def test_tiers_shape_validation_wrong_type_raises(self):
+        # [tests].tiers must be a list.  A string value must fail with
+        # ConfigurationError naming both 'tiers' and 'tier'.
+        cfg = copy.deepcopy(MINIMAL_CONFIG)
+        cfg["tests"]["tiers"] = "tier3"  # string instead of list
+        po = _make_partial_opts(config=cfg)
+        with self.assertRaises(ConfigurationError) as ctx:
+            po._validate_static_configuration()
+        msg = str(ctx.exception)
+        self.assertIn("tiers", msg)
+
+    def test_tier_mapping_wrong_type_raises(self):
+        # [tests].tier must be a table (dict).  A list value must fail with
+        # ConfigurationError naming both keys.
+        cfg = copy.deepcopy(MINIMAL_CONFIG)
+        cfg["tests"]["tier"] = ["tier0", "tier1"]  # list instead of dict
+        po = _make_partial_opts(config=cfg)
+        with self.assertRaises(ConfigurationError) as ctx:
+            po._validate_static_configuration()
+        msg = str(ctx.exception)
+        self.assertIn("tier", msg)
+
+
+# ---------------------------------------------------------------------------
+# 7. Bundled default configuration — ships with correct defaults
+# ---------------------------------------------------------------------------
+
+
+class TestBundledDefaultConfig(unittest.TestCase):
+    def test_bundled_default_config_has_tiers(self):
+        """Pins the shipped default — the crash guard for tier resolution."""
+        import tomllib
+        from importlib.resources import files
+        from pathlib import Path
+
+        try:
+            bundled = Path(files("enge.utils") / "enge_default_config.toml")
+        except (TypeError, ValueError, ModuleNotFoundError):
+            bundled = (
+                Path(__file__).parent.parent
+                / "src"
+                / "enge"
+                / "utils"
+                / "enge_default_config.toml"
+            )
+        with open(bundled, "rb") as f:
+            config = tomllib.load(f)
+        self.assertEqual(config["tests"]["tiers"], ["tier3"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 (tier fallback, empty-string, endpont errors, validation details)

Four behavior changes, each driven by a flipped characterization pin:

Item 1 — Tier selection never reads [tests].tier (the filter-definition mapping).
  resolve_effective_values now uses an explicit if-elif chain: CLI > set tiers > [tests].tiers.
  When all three sources are absent, ConfigurationError is raised instead of returning None.
  Added tiers = ['tier3'] to bundled defaults as the catch-all fallback.
  Shape validation in _validate_static_configuration rejects wrong types for both keys.
  log_fallbacks=True param added: validation-pass calls pass False to silence the INFO line
  there; it prints exactly once per resolution (in the real init pass).
  Flipped pins:
    test_set_with_no_tier_resolves_to_tests_tiers_default (was crash KeyError: 0, now ['tier3'])
    test_tests_tier_mapping_not_used_for_tier_selection (was assertIsNone, now assertRaises ConfigurationError)
    test_tiers_shape_validation_wrong_type_raises (new)
    test_tier_mapping_wrong_type_raises (new)
    test_cli_tier_overrides_tests_tiers_default (new)
    test_set_tiers_override_tests_tiers_default (new)
    test_bundled_default_config_has_tiers (new; pins shipped default — crash guard)
    test_no_tiers_anywhere_raises_configuration_error (new; unit-tests ConfigurationError directly)
    test_tier_fallback_log_emitted_exactly_once (new; asserts INFO prints exactly once)
  Mutation proof (bundled-default mutation): delete tiers from enge_default_config.toml →
    test_bundled_default_config_has_tiers fails (KeyError: 'tiers').
  Mutation proof (code mutation): revert raise to None →
    test_no_tiers_anywhere_raises_configuration_error and
    test_tests_tier_mapping_not_used_for_tier_selection fail.

Item 2 — Empty string ("") treated as absent at every layer.
  merge_configs inherits the default when user config supplies "" or None and a real
  default exists.  _validate_operational_defaults checks only None (not "").
  _warn_empty_user_values logs one WARNING per key that inherits a default.
  Flipped pins:
    test_empty_string_key_no_longer_raises_configuration_error (was assertRaises, now no-raise)
    test_none_key_still_raises_configuration_error (new; verifies None still raises)
    test_user_empty_string_inherits_default (was assertEqual ""; now assertEqual "default-value")
    test_user_none_inherits_default (same flip)
  Unchanged pins:
    test_non_empty_api_key_not_replaced_by_env 
    test_validate_opts_propagates_configuration_error 

Item 3 — TestingFarmEndpoint raises ConfigurationError, not ValueError.
  Flipped pins:
    test_empty_endpoint_url_raises_configuration_error (was assertRaises ValueError,
      now assertRaises ConfigurationError; assertIn "api_endpoint_url" in message)
    test_both_urls_required (now asserts ConfigurationError with per-key assertions)

Item 4 — Validation errors include collected detail lines in the exception message.
  All four validators join their error list into the exception string.
  Flipped pins:
    test_missing_common_section_raises_configuration_error (assertIn "common" in msg)
    test_test_action_without_cli_or_config_arch_raises (assertIn "architectures" in msg)
    test_unknown_tier_raises_with_available_tiers_listed (assertIn "tier99" in msg)

251 tests green (up from 239 before branch, 248 after initial commit); ruff and pre-commit clean; no new ratchet entries.