### PR TITLE
feat: auto-set skip_guest_setup for RHUI source composes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Automatic `skip_guest_setup` pipeline setting for RHUI source composes (`RHEL-*-rhui`, `RHEL-*-sap-rhui`, `RHEL-*-sap-ha-rhui`)
 - Short flags: `-s` (source), `-t` (target), `-T` (tier), `-p` (plan), `-S` (set), `-n` (dryrun)
 - Verbosity control: `-v` for VERBOSE level, `-vv` / `--debug` for DEBUG level
 - Output format selection: `-o` / `--format` with `terminal`, `json`, `gitlab` modes

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ enge test --source 9.7 --plan /plans/subscription --only-rhsm-stage-cdn
   - **Alias mode**: define aliases in `[sources.ami]` in `enge.toml`, e.g. `alma97 = 'AlmaLinux OS 9.7.20251118'`, `rocky97 = 'Rocky-9-EC2-Base-9.7-20251123.2'`, then use `--source alma97` / `--source rocky97`.
   - **Direct mode**: pass full AMI source names directly (with or without architecture suffix), e.g. `AlmaLinux OS 9.7.20251118 x86_64`, `Rocky-9-EC2-Base-9.7-20251123.2.aarch64`.
   - For AMI sources, only `x86_64` and `aarch64` architectures are supported.
+- **RHUI sources** (`RHEL-8-rhui`, `RHEL-8-sap-rhui`, `RHEL-8-sap-ha-rhui`) are passed through as-is without compose pinning. When an RHUI source is detected, `skip_guest_setup` is automatically set in the Testing Farm request pipeline settings.
 - When CentOS Stream is the source, the `--target` argument may be provided as a major version only (e.g., `10`); it is automatically interpreted internally as `<major>.0` for compose pinning.
 - When a simple version is provided, enge attempts to pin it to an actual compose name by consulting `testing_farm.composes_prod_url` from the configuration. It tries the following formats in order:
   - `RHEL-MAJOR.MINOR.0-Nightly` (RHEL 8/9 style)

--- a/src/enge/dispatch/set_flow.py
+++ b/src/enge/dispatch/set_flow.py
@@ -202,6 +202,10 @@ def _configure_submit_test(spec, resolved_opts, shared_archive_filename):
         or resolved_opts.tests.get("parallel_limit")
     )
 
+    if spec.source_spec.get("compose_name", "").endswith("-rhui"):
+        submit_test.skip_guest_setup = True
+        LOGGER.info("RHUI source detected — setting skip_guest_setup=true")
+
     submit_test.set_auto_tags(
         set_name=spec.set_name,
         architecture=spec.arch,

--- a/src/enge/dispatch/tf_send_request.py
+++ b/src/enge/dispatch/tf_send_request.py
@@ -63,6 +63,7 @@ class SubmitTest:
         self.business_unit_tag: Optional[str] = None
         self.tmt_distro: Optional[str] = None
         self.parallel_limit: Optional[int] = None
+        self.skip_guest_setup: bool = False
         self.authorization_header: Dict[str, str] = {}
         self.payload_raw: Dict[str, Any] = {}
         self.latest_tasks_file: Optional[str] = None
@@ -424,11 +425,14 @@ class SubmitTest:
             if pool:
                 environment_config["pool"] = pool
 
-            environment_config["settings"] = {
+            env_settings = {
                 "provisioning": {
                     "tags": {"BusinessUnit": self.business_unit_tag},
                 }
             }
+            if self.skip_guest_setup:
+                env_settings["pipeline"] = {"skip_guest_setup": True}
+            environment_config["settings"] = env_settings
             environment_config["tmt"] = tmt_config
             environment_config["variables"] = regular_env_vars
 

--- a/tests/test_set_flow.py
+++ b/tests/test_set_flow.py
@@ -182,6 +182,73 @@ class TestSetFlow(unittest.TestCase):
         self.assertEqual(result["set_name"], "fail-set")
         self.assertIn("error", result)
 
+    @patch("enge.dispatch.set_flow._get_parsed_opts")
+    def test_configure_submit_test_sets_skip_guest_setup_for_rhui(
+        self, mock_parsed_opts
+    ):
+        po = MagicMock()
+        po.testing_farm = {"api_key": "token"}
+        po.tests = {
+            "git_url": "https://git.example/repo",
+            "git_ref": "main",
+            "parallel_limit": 5,
+            "tier": {},
+        }
+        po.project = {"repo_url": "https://git.example/repo"}
+        po.cli_args = MagicMock()
+        po.cli_args.git_url = None
+        po.cli_args.git_ref = None
+        po.cli_args.testfilter = None
+        po.cli_args.test = None
+        po.cli_args.auto_tag = False
+        po.cli_args.set_tag = None
+        mock_parsed_opts.return_value = po
+
+        from enge.dispatch.set_flow import _configure_submit_test
+
+        rhui_cases = [
+            ("RHEL-8-rhui", True),
+            ("RHEL-9-sap-rhui", True),
+            ("RHEL-8-sap-ha-rhui", True),
+            ("RHEL-9.2.0", False),
+            ("CentOS-Stream-9", False),
+        ]
+        for compose_name, expected in rhui_cases:
+            with self.subTest(compose_name=compose_name):
+                spec = RequestSpec(
+                    set_name="test",
+                    tier="sanity",
+                    plan="/plans/p1",
+                    arch="x86_64",
+                    source_spec={
+                        "major": 8,
+                        "minor": 0,
+                        "compose_name": compose_name,
+                    },
+                    target_spec={
+                        "major": 9,
+                        "minor": 0,
+                        "compose_name": "RHEL-9.0.0",
+                    },
+                    upgrade_path="rhel-8-to-9",
+                    effective_values={},
+                )
+                with patch(
+                    "enge.dispatch.tf_send_request.parsed_opts",
+                    new=MagicMock(
+                        testing_farm_endpoint=MagicMock(
+                            log_artifact_baseurl="http://logs",
+                            api_endpoint_url="http://api",
+                        )
+                    ),
+                ):
+                    submit = _configure_submit_test(spec, po, "shared")
+                self.assertEqual(
+                    submit.skip_guest_setup,
+                    expected,
+                    f"{compose_name}: expected skip_guest_setup={expected}",
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tf_send_request.py
+++ b/tests/test_tf_send_request.py
@@ -45,5 +45,66 @@ class TestBuildPayload(unittest.TestCase):
             )
 
 
+class TestSkipGuestSetup(unittest.TestCase):
+    def _make_submit(self, parsed_stub):
+        with patch.object(tf_send_request, "parsed_opts", parsed_stub):
+            submit = tf_send_request.SubmitTest()
+        submit.api_key = "token"
+        submit.tests_git_url = "https://example.com/tests.git"
+        submit.tests_git_ref = "main"
+        submit.plan = "/plans/smoke"
+        submit.compose = "RHEL-8-rhui"
+        submit.business_unit_tag = "eng"
+        submit.tmt_distro = "rhel-8"
+        submit.parallel_limit = 1
+        submit.set_specific_data(
+            architectures=["x86_64"],
+            environment_variables={},
+            tmt_context={"distro": "rhel-8"},
+        )
+        return submit
+
+    def _parsed_stub(self):
+        return SimpleNamespace(
+            cli_args=SimpleNamespace(dryrun=False),
+            environment_variables={},
+            tmt_context={},
+            architectures=["x86_64"],
+            testing_farm_endpoint=SimpleNamespace(
+                log_artifact_baseurl="http://logs", api_endpoint_url="http://api"
+            ),
+        )
+
+    def test_skip_guest_setup_in_payload_when_enabled(self):
+        stub = self._parsed_stub()
+        submit = self._make_submit(stub)
+        submit.skip_guest_setup = True
+        with patch.object(tf_send_request, "parsed_opts", stub):
+            _, payload = submit.build_payload()
+
+        env_settings = payload["environments"][0]["settings"]
+        self.assertIn("pipeline", env_settings)
+        self.assertTrue(env_settings["pipeline"]["skip_guest_setup"])
+
+    def test_no_pipeline_in_env_settings_when_disabled(self):
+        stub = self._parsed_stub()
+        submit = self._make_submit(stub)
+        submit.skip_guest_setup = False
+        with patch.object(tf_send_request, "parsed_opts", stub):
+            _, payload = submit.build_payload()
+
+        env_settings = payload["environments"][0]["settings"]
+        self.assertNotIn("pipeline", env_settings)
+
+    def test_skip_guest_setup_default_is_false(self):
+        with patch.object(
+            tf_send_request,
+            "parsed_opts",
+            self._parsed_stub(),
+        ):
+            submit = tf_send_request.SubmitTest()
+        self.assertFalse(submit.skip_guest_setup)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
RHUI composes (RHEL-*-rhui, RHEL-*-sap-rhui, RHEL-*-sap-ha-rhui) require the Testing Farm pipeline setting skip_guest_setup=true. Detect the -rhui suffix on the source compose name during request configuration and inject the setting into each environment's settings.pipeline dict automatically.