### PR TITLE
Extend rhui definitions to skip repinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
-- Automatic `skip_guest_setup` pipeline setting for RHUI source composes (`RHEL-*-rhui`, `RHEL-*-sap-rhui`, `RHEL-*-sap-ha-rhui`)
+- Automatic `skip_guest_setup` pipeline setting for RHUI source composes (`RHEL-<major>-rhui`, `RHEL-<major>-sap-hana-rhui`, `RHEL-<major>-sap-netweaver-rhui`)
 - Short flags: `-s` (source), `-t` (target), `-T` (tier), `-p` (plan), `-S` (set), `-n` (dryrun)
 - Verbosity control: `-v` for VERBOSE level, `-vv` / `--debug` for DEBUG level
 - Output format selection: `-o` / `--format` with `terminal`, `json`, `gitlab` modes

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ enge test --source 9.7 --plan /plans/subscription --only-rhsm-stage-cdn
   - **Alias mode**: define aliases in `[sources.ami]` in `enge.toml`, e.g. `alma97 = 'AlmaLinux OS 9.7.20251118'`, `rocky97 = 'Rocky-9-EC2-Base-9.7-20251123.2'`, then use `--source alma97` / `--source rocky97`.
   - **Direct mode**: pass full AMI source names directly (with or without architecture suffix), e.g. `AlmaLinux OS 9.7.20251118 x86_64`, `Rocky-9-EC2-Base-9.7-20251123.2.aarch64`.
   - For AMI sources, only `x86_64` and `aarch64` architectures are supported.
-- **RHUI sources** (`RHEL-8-rhui`, `RHEL-8-sap-rhui`, `RHEL-8-sap-ha-rhui`) are passed through as-is without compose pinning. When an RHUI source is detected, `skip_guest_setup` is automatically set in the Testing Farm request pipeline settings.
+- **RHUI sources** (`RHEL-<major>-rhui`, `RHEL-<major>-sap-hana-rhui`, `RHEL-<major>-sap-netweaver-rhui`, and other `RHEL-<major>-<middle>-rhui` variants) are passed through as-is without compose pinning. When an RHUI source is detected, `skip_guest_setup` is automatically set in the Testing Farm request pipeline settings.
 - When CentOS Stream is the source, the `--target` argument may be provided as a major version only (e.g., `10`); it is automatically interpreted internally as `<major>.0` for compose pinning.
 - When a simple version is provided, enge attempts to pin it to an actual compose name by consulting `testing_farm.composes_prod_url` from the configuration. It tries the following formats in order:
   - `RHEL-MAJOR.MINOR.0-Nightly` (RHEL 8/9 style)

--- a/src/enge/utils/arg_parser.py
+++ b/src/enge/utils/arg_parser.py
@@ -196,7 +196,8 @@ def get_arguments(args: Optional[list] = None) -> argparse.Namespace:
         required=False,  # Will be validated later based on whether --set is provided
         help="Source compose to be upgraded. "
         "Can be provided in a format of <major>.<minor> (e.g. 8.10), explicit compose name (e.g. RHEL-8.10.0-Nightly), "
-        "symbolic RHUI compose (e.g. RHEL-8-rhui, RHEL-8-sap-rhui, RHEL-8-sap-ha-rhui), "
+        "symbolic RHUI compose (e.g. RHEL-8-rhui, RHEL-8-sap-hana-rhui, "
+        "RHEL-8-sap-netweaver-rhui), "
         "CentOS Stream format (e.g. CentOS-Stream-9, stream-9, cs-9, stream9, cs9), "
         "or AMI source alias/name for Alma Linux or Rocky Linux (e.g. alma97, rocky97, "
         "'AlmaLinux OS 9.7.20251118 x86_64'). AMI aliases are configured in [sources.ami]. "

--- a/src/enge/utils/source_target_parser.py
+++ b/src/enge/utils/source_target_parser.py
@@ -30,9 +30,10 @@ AMI_ARCH_SEPARATORS = {"alma": " ", "rocky": "."}
 # Only these architectures are available for AMI sources on AWS EC2
 VALID_AMI_ARCHITECTURES = {"x86_64", "aarch64"}
 
-# Symbolic RHEL composes (pass-through to Testing Farm, no repinning)
+# Symbolic RHEL composes (pass-through to Testing Farm, no repinning).
+# RHEL-<major>[-<dash-separated-middle>]-rhui (e.g. RHEL-8-rhui, RHEL-8-sap-hana-rhui).
 SYMBOLIC_RHEL_COMPOSE_PATTERN = re.compile(
-    r"^RHEL-(\d+)-(rhui|sap-rhui|sap-ha-rhui)$",
+    r"^RHEL-(\d+)(?:-(.+))?-rhui$",
     re.IGNORECASE,
 )
 
@@ -268,8 +269,11 @@ def parse_compose_spec(
     rhui_match = SYMBOLIC_RHEL_COMPOSE_PATTERN.match(spec_stripped)
     if rhui_match:
         major = int(rhui_match.group(1))
-        suffix = rhui_match.group(2).lower()
-        compose_name = f"RHEL-{major}-{suffix}"
+        middle = rhui_match.group(2)
+        if middle:
+            compose_name = f"RHEL-{major}-{middle.lower()}-rhui"
+        else:
+            compose_name = f"RHEL-{major}-rhui"
         LOGGER.debug(f"Parsed symbolic RHUI spec '{spec_stripped}' as: {compose_name}")
         return {
             "major": major,

--- a/tests/test_set_flow.py
+++ b/tests/test_set_flow.py
@@ -214,8 +214,8 @@ class TestSetFlow(unittest.TestCase):
 
         rhui_cases = [
             ("RHEL-8-rhui", True),
-            ("RHEL-9-sap-rhui", True),
-            ("RHEL-8-sap-ha-rhui", True),
+            ("RHEL-8-sap-hana-rhui", True),
+            ("RHEL-8-sap-netweaver-rhui", True),
             ("RHEL-9.2.0", False),
             ("CentOS-Stream-9", False),
         ]

--- a/tests/test_source_target_parser.py
+++ b/tests/test_source_target_parser.py
@@ -143,9 +143,9 @@ class TestSourceTargetParser(unittest.TestCase):
     def test_symbolic_rhui_compose_specs(self):
         cases = [
             ("RHEL-8-rhui", "RHEL-8-rhui"),
-            ("RHEL-9-sap-rhui", "RHEL-9-sap-rhui"),
-            ("RHEL-8-sap-ha-rhui", "RHEL-8-sap-ha-rhui"),
-            ("rhel-8-rhui", "RHEL-8-rhui"),
+            ("RHEL-8-sap-hana-rhui", "RHEL-8-sap-hana-rhui"),
+            ("RHEL-8-sap-netweaver-rhui", "RHEL-8-sap-netweaver-rhui"),
+            ("rhel-8-sap-hana-rhui", "RHEL-8-sap-hana-rhui"),
         ]
         for spec, expected_compose in cases:
             with self.subTest(spec=spec):
@@ -156,6 +156,17 @@ class TestSourceTargetParser(unittest.TestCase):
                 self.assertTrue(parsed["is_major_only"])
                 self.assertFalse(parsed["is_centos_stream"])
                 self.assertFalse(parsed["is_ami_source"])
+
+    def test_non_rhui_compose_specs_rejected(self):
+        invalid_specs = [
+            "RHEL-8",
+            "RHEL-8-sap-hana",
+            "RHEL-8-sap-netweaver",
+        ]
+        for spec in invalid_specs:
+            with self.subTest(spec=spec):
+                with self.assertRaises(ValueError):
+                    parse_compose_spec(spec, self.minimal_config)
 
     def test_symbolic_rhui_source_target_config(self):
         source_spec, target_spec = parse_source_target_config(


### PR DESCRIPTION
* extend by using wildcard for the potential middle part with the convetnion being always RHEL-<major> prefix and -rhui suffix