### PR TITLE
ci: add mypy type gate, TZ matrix, collector parity guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,20 @@ jobs:
         with:
           python-version: "3.11"
       - uses: pre-commit/action@v3.0.1
+      - name: Install project for type checking
+        run: |
+          sudo apt-get install -y libxml2-dev libxslt-dev libkrb5-dev
+          pip install -e . mypy
+      - name: Type check (mypy)
+        run: mypy src/enge
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tz: [UTC, America/Los_Angeles]
+    env:
+      TZ: ${{ matrix.tz }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -28,4 +39,7 @@ jobs:
           cache-dependency-path: setup.cfg
       - run: sudo apt-get install -y libxml2-dev libxslt-dev libkrb5-dev
       - run: pip install -e . pytest
-      - run: python -m pytest tests/ -q
+      - name: Run tests (TZ=${{ matrix.tz }})
+        run: python -m pytest tests/ -q
+      - name: Collector parity guard
+        run: python scripts/check_collector_parity.py

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,57 @@
+[mypy]
+python_version = 3.11
+ignore_missing_imports = True
+check_untyped_defs = True
+
+# Baseline ratchet — remove entries as modules are annotated. Never add entries.
+
+[mypy-enge.cancel.__main__]  # 2 errors
+ignore_errors = True
+
+[mypy-enge.dispatch.__main__]  # 4 errors
+ignore_errors = True
+
+[mypy-enge.dispatch.pin_compose]  # 1 error
+ignore_errors = True
+
+[mypy-enge.dispatch.set_flow]  # 1 error
+ignore_errors = True
+
+[mypy-enge.dispatch.tf_send_request]  # 1 error
+ignore_errors = True
+
+[mypy-enge.report.__main__]  # 2 errors
+ignore_errors = True
+
+[mypy-enge.report.concurrent_parser]  # 5 errors
+ignore_errors = True
+
+[mypy-enge.reportportal.__main__]  # 1 error
+ignore_errors = True
+
+[mypy-enge.reportportal.operations]  # 2 errors
+ignore_errors = True
+
+[mypy-enge.reportportal.utils]  # 3 errors
+ignore_errors = True
+
+[mypy-enge.rerun.__main__]  # 9 errors
+ignore_errors = True
+
+[mypy-enge.utils.arg_parser]  # 1 error
+ignore_errors = True
+
+[mypy-enge.utils.config_parser]  # 1 error
+ignore_errors = True
+
+[mypy-enge.utils.reportportal_helper]  # 1 error
+ignore_errors = True
+
+[mypy-enge.utils.source_target_parser]  # 1 error
+ignore_errors = True
+
+[mypy-enge.utils.task_resolver]  # 1 error
+ignore_errors = True
+
+[mypy-enge.utils.tf_artifact]  # 3 errors
+ignore_errors = True

--- a/scripts/check_collector_parity.py
+++ b/scripts/check_collector_parity.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Guard: pytest and unittest must discover identical test counts.
+
+A divergence means pytest-style bare-function tests crept in
+(unittest silently skips them).
+"""
+import re
+import subprocess
+import sys
+
+
+def pytest_count():
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", "tests/"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode not in (0, 5):
+        print(
+            f"FAIL: pytest collection failed (rc={result.returncode}):",
+            file=sys.stderr,
+        )
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+
+    for line in reversed(result.stdout.strip().splitlines()):
+        m = re.search(r"(\d+) tests? collected", line)
+        if m:
+            return int(m.group(1))
+
+    print("FAIL: could not parse pytest collection count", file=sys.stderr)
+    print(result.stdout, file=sys.stderr)
+    sys.exit(1)
+
+
+def unittest_count():
+    result = subprocess.run(
+        [sys.executable, "-m", "unittest", "discover", "-s", "tests"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"FAIL: unittest discover failed (rc={result.returncode}):",
+            file=sys.stderr,
+        )
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+
+    for line in result.stderr.splitlines():
+        m = re.search(r"Ran (\d+) tests? in", line)
+        if m:
+            return int(m.group(1))
+
+    print("FAIL: could not parse unittest test count", file=sys.stderr)
+    print(result.stderr, file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    pc = pytest_count()
+    uc = unittest_count()
+
+    print(f"pytest:   {pc}")
+    print(f"unittest: {uc}")
+
+    if pc != uc:
+        print(
+            f"\nFAIL: collector parity violated ({pc} vs {uc}). "
+            "Bare-function tests are invisible to unittest discover.",
+        )
+        sys.exit(1)
+
+    print("OK: collectors agree")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Two runtime-crash regressions (missing positional arg, renamed keyword) shipped through CI undetected — both are statically catchable.

- mypy step in lint job with check_untyped_defs; per-module ignore-errors ratchet for the 17-module baseline (same pattern as the ruff ratchet)
- TZ matrix on test job: UTC + America/Los_Angeles (two real TZ bugs were found in this codebase)
- Collector parity guard: fails if pytest and unittest discover diverge, catching bare-function tests that unittest silently skips
- Correct invocation preserved: python -m pytest, pip install -e .

Action versions already at v6 (Node 20+), no bump needed.