### PR TITLE
fix: match multi-set runs by per-request set fields in find_runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `src/__init__.py` (src directory must not be a Python package)
 
 ### Fixed
+- Multi-set runs are now found by `--set <name>` for every dispatched set, not only the first; `find_runs` matches per-request set fields in addition to the run's context
 - Rerun manifests now record `parent_run_id` and inherit the parent run's tags when tasks are resolved from a manifest; previously lineage was always empty despite the documented feature (the `ManifestWriter` was constructed with hardcoded `parent_run_id=None` and tags came only from CLI `--set-tag`)
 - Multi-set dispatch (`-S setA -S setB`) previously resolved build artifacts from the first set's configuration for ALL sets; each set now resolves its own `copr_api`/`brew_api` `build_references` (per-family precedence, evaluated independently: CLI `--copr`/`--brew` > set-level config > run-level config)
 - ReportPortal timestamps (launch end-times, log upload times) were sent in local time mislabeled as UTC; now genuinely UTC

--- a/src/enge/dispatch/__main__.py
+++ b/src/enge/dispatch/__main__.py
@@ -337,7 +337,8 @@ def _build_manifest_writer(ctx):
     context = {}
     set_names = getattr(ctx.cli_args, "set", None)
     if set_names:
-        context["set"] = set_names[0] if len(set_names) == 1 else set_names[0]
+        # Per-request set fields are authoritative for multi-set runs.
+        context["set"] = set_names[0]
     context["event"] = eff.get("event") or getattr(ctx.cli_args, "event", None)
     if hasattr(ctx, "source_spec") and ctx.source_spec:
         src = ctx.source_spec

--- a/src/enge/utils/manifest.py
+++ b/src/enge/utils/manifest.py
@@ -139,8 +139,9 @@ class ManifestReader:
         all_runs = ManifestReader.list_runs(runs_dir)
         results = []
         for summary in all_runs:
-            if set_name and summary.get("context", {}).get("set") != set_name:
-                continue
+            ctx_set_matches = (
+                not set_name or summary.get("context", {}).get("set") == set_name
+            )
             if tag and tag not in summary.get("tags", []):
                 continue
             created = summary.get("created_at", "")
@@ -154,9 +155,13 @@ class ManifestReader:
                         continue
                     if until and dt > until:
                         continue
-            if tier or arch:
+            if not ctx_set_matches or tier or arch:
                 full = ManifestReader.load(Path(summary["path"]))
                 requests = full.get("requests", [])
+                if not ctx_set_matches and not any(
+                    r.get("set") == set_name for r in requests
+                ):
+                    continue
                 if tier and not any(r.get("tier") == tier for r in requests):
                     continue
                 if arch and not any(r.get("arch") == arch for r in requests):

--- a/tests/test_manifest_integration.py
+++ b/tests/test_manifest_integration.py
@@ -382,5 +382,55 @@ class TestSinceUntilManifestRouting(unittest.TestCase):
         self.assertIn(task_uuid, resolved_uuids)
 
 
+class TestFindRunsMultiSetMatching(unittest.TestCase):
+    """find_runs must match per-request set fields, not only context.set."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmpdir.name)
+        self.runs = self.tmp / "runs"
+        self.latest = self.tmp / "latest"
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+
+    def _write_multiset_manifest(self):
+        rid = generate_ulid()
+        w = ManifestWriter(
+            run_id=rid,
+            command="test",
+            argv=["enge", "test", "-S", "alpha", "-S", "beta"],
+            context={"set": "alpha"},
+        )
+        w.add_request("uuid-alpha-1", set_name="alpha", tier="tier0", arch="x86_64")
+        w.add_request("uuid-beta-1", set_name="beta", tier="tier0", arch="x86_64")
+        w.flush(self.runs, self.latest)
+        return rid
+
+    def test_find_runs_matches_non_context_set_via_requests(self):
+        """A multi-set run with context.set='alpha' must be found by set_name='beta'."""
+        from enge.utils.manifest import ManifestReader
+
+        self._write_multiset_manifest()
+        results = ManifestReader.find_runs(self.runs, set_name="beta")
+        self.assertEqual(len(results), 1, "multi-set run not found by non-context set")
+
+    def test_find_runs_still_matches_context_set(self):
+        """context.set match must still work (single-set and migrated compat)."""
+        from enge.utils.manifest import ManifestReader
+
+        self._write_multiset_manifest()
+        results = ManifestReader.find_runs(self.runs, set_name="alpha")
+        self.assertEqual(len(results), 1)
+
+    def test_find_runs_no_match_for_absent_set(self):
+        """A set name present in neither context nor requests must not match."""
+        from enge.utils.manifest import ManifestReader
+
+        self._write_multiset_manifest()
+        results = ManifestReader.find_runs(self.runs, set_name="gamma")
+        self.assertEqual(len(results), 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
find_runs previously matched set_name only against context.set, which records the first set name. Multi-set runs (-S alpha -S beta) were invisible to --set beta queries. Now falls through to per-request set fields when the context doesn't match, unified with the existing full-manifest load path for tier/arch filters.

Also removes the identical-branch ternary in _build_manifest_writer (context.set was set_names[0] regardless of list length).