### PR TITLE
chore: correct _resolve_launch_name return annotation to Optional[str]

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -39,9 +39,6 @@ disable_error_code = assignment
 [mypy-enge.utils.config_parser]  # arg-type (Traversable vs PathLike)
 disable_error_code = arg-type
 
-[mypy-enge.utils.reportportal_helper]  # return-value (str|None declared as str)
-disable_error_code = return-value
-
 [mypy-enge.utils.source_target_parser]  # var-annotated
 disable_error_code = var-annotated
 

--- a/src/enge/utils/reportportal_helper.py
+++ b/src/enge/utils/reportportal_helper.py
@@ -19,7 +19,7 @@ from enge.utils.source_target_parser import (
 LOGGER = logging.getLogger(__name__)
 
 
-def _resolve_launch_name(context: Optional[Dict[str, Any]], ctx) -> str:
+def _resolve_launch_name(context: Optional[Dict[str, Any]], ctx) -> Optional[str]:
     """Derive a ReportPortal launch name using config + context rules."""
     rp_env_vars = generate_reportportal_environment_variables(
         ctx.config,


### PR DESCRIPTION
_resolve_launch_name returns rp_env_vars.get(launch_key), which is None whenever generate_reportportal_environment_variables's auto-generation path yields no name segments (empty/minimal context, no [reportportal].launch config, no --rp-launch override). The -> str annotation was wrong; mypy.ini already carried a ratchet entry for this exact mismatch ("return-value (str|None declared as str)").

No runtime change: the sole caller (create_launch, same file) forwards the value unmodified into ReportPortalLaunch.generate_launch_payload() and .create_launch(), both typed Optional[str] with an existing `if not name: name = self.generate_launch_name(context)` fallback -- None was already handled correctly at the point of use.

Annotation-only fix shrinks the mypy ratchet: the
[mypy-enge.utils.reportportal_helper] entry is removed entirely (mypy src/enge passes clean with no other latent issues in this module).