### PR TITLE
chore: move manifest resolution to utils/manifest_resolution.py

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ src/enge/
   utils/             opt_manager (config loading + validation: ParsedOpts), app_context
                      (runtime DI container), globals (ExitCode + worst_exit_code),
                      task_resolver (shared task-ID resolution: manifest, legacy, -i/-f),
+                     manifest_resolution (shared invocation→manifest-object
+                     resolution: report results cache, future `enge compare`),
                      test_attribute_builder (computed test attrs for AppContext),
                      manifest/state_paths/ulid/legacy_archive (manifest store + XDG paths),
                      arg_parser, console, source_target_parser, tf_artifact (COPR/Brew),
@@ -174,8 +176,10 @@ write API (`utils/results_parser.py`) is standalone and does not import
 manifest modules, by design — callers pass expected counts and all
 needed values explicitly. Report-subcommand integration lives in
 `report/results_cache.py` (`cache_report_results`, wired into
-`report/__main__.main()`), which owns the manifest lookup that
-`results_parser.py` deliberately does not.
+`report/__main__.main()`), which delegates manifest lookup — which
+`results_parser.py` deliberately does not own — to
+`utils/manifest_resolution.py`'s `resolve_manifests_for_invocation`
+(imported into `results_cache.py` as `_resolve_manifests_for_report`).
 
 **Report write policy (implemented in `report/results_cache.py`)**:
 caching is a side effect of `enge report`, never a behavior change to
@@ -184,11 +188,12 @@ its table output or exit code.
   structured filters `--set`/`--tier`/`--arch`/`--tag`) gap-fill
   `results.json` + verbatim xunit for **every** matched run — a filter
   selector matching N runs produces N cache files. Manifest resolution
-  is re-derived independently in `results_cache.py` (mirroring, not
-  importing, `utils/task_resolver.py`'s precedence) because this module
-  needs full manifest objects and run_id-per-task attribution across
-  possibly-multiple matched runs, not `task_resolver`'s flat task_id
-  list.
+  is independently re-derived in `utils/manifest_resolution.py`
+  (mirroring, not importing, `utils/task_resolver.py`'s precedence)
+  because it needs full manifest objects and run_id-per-task attribution
+  across possibly-multiple matched runs, not `task_resolver`'s flat
+  task_id list. Shared with the planned `enge compare` subcommand so
+  that selector precedence isn't reimplemented a third time.
 - **Raw-input invocations** (`-f/--file`, `-i/--input`, or the legacy
   `--get-tag`/bare-date archive path) never write a cache — there is no
   resolvable run_id to key on. No flag opts out of caching for

--- a/src/enge/report/results_cache.py
+++ b/src/enge/report/results_cache.py
@@ -7,25 +7,27 @@ invocations (`--file`/`--input`, or any selector with no resolvable
 run_id) are a no-op -- see CLAUDE.md "Results.json format" for the full
 write policy and terminality predicate.
 
-Manifest lookup lives here rather than in `utils/task_resolver.py`
-because this module needs full manifest objects (envelope fields +
-per-request metadata, and run_id-per-task attribution across the
-possibly-multiple runs a filter selector can match) rather than the flat
-task_id list `task_resolver` hands to the xunit fetch layer. This keeps
+Invocation -> manifest resolution lives in `utils/manifest_resolution.py`
+(`resolve_manifests_for_invocation`, aliased here as
+`_resolve_manifests_for_report`) rather than in `utils/task_resolver.py`,
+because it needs full manifest objects (envelope fields + per-request
+metadata, and run_id-per-task attribution across the possibly-multiple
+runs a filter selector can match) rather than the flat task_id list
+`task_resolver` hands to the xunit fetch layer. This keeps
 `results_parser` import-free of manifest code (by design) and keeps
 `task_resolver`'s contract unchanged.
 """
 
 import logging
-from datetime import timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import lxml.etree  # type: ignore
 
-from enge.utils import parse_date_arg
 from enge.utils.errors import ConflictError, ValidationError
-from enge.utils.manifest import ManifestReader
+from enge.utils.manifest_resolution import (
+    resolve_manifests_for_invocation as _resolve_manifests_for_report,
+)
 from enge.utils.results_parser import (
     XUNIT_RESULT_MAP,
     finalize_root_verdict,
@@ -196,72 +198,6 @@ def _build_task_entry(
         "total_duration_seconds": total_duration,
         "plans": plans,
     }
-
-
-def _resolve_manifests_for_report(ctx: "AppContext") -> List[Dict[str, Any]]:
-    """Independently resolve which manifest(s) this report invocation is
-    backed by. Mirrors utils/task_resolver.py's precedence (file > input >
-    tags/date-only-without-manifest-filters -> legacy archive > no-args ->
-    latest manifest > --run / filter selectors -> manifest store) closely
-    enough to agree with it on manifest-backed vs. raw-input, but is not
-    imported from it: task_resolver hands back a flat task_id list tuned
-    for the xunit fetch layer, not the full manifest objects (and
-    run_id-per-task attribution across N matched runs) this module needs.
-
-    Returns [] for raw-input invocations -- the caller no-ops in that
-    case."""
-    cli_args = ctx.cli_args
-    runs_dir = Path(ctx.manifest_runs_dir)
-
-    if getattr(cli_args, "file", None):
-        return []
-    if getattr(cli_args, "input", None):
-        return []
-
-    since_str = getattr(cli_args, "since", None)
-    until_str = getattr(cli_args, "until", None)
-    has_tags = bool(getattr(cli_args, "get_tag", None))
-    has_date_filter = bool(since_str or until_str)
-    has_manifest_filters = any(
-        getattr(cli_args, attr, None)
-        for attr in ("filter_set", "filter_tier", "filter_arch", "filter_tag", "run")
-    )
-
-    if (has_tags or has_date_filter) and not has_manifest_filters:
-        # Legacy archive path (--get-tag, or bare --since/--until with no
-        # manifest filters) -- no resolvable run_id.
-        return []
-
-    if not any((has_tags, has_date_filter, has_manifest_filters)):
-        # No selector at all: the latest manifest, if one exists. (If not,
-        # task_resolver falls back to the legacy latest-jobs file, which
-        # is also not manifest-backed -- nothing to cache either way.)
-        manifest_data = ManifestReader.load_latest(Path(ctx.manifest_latest))
-        return [manifest_data] if manifest_data else []
-
-    run_id = getattr(cli_args, "run", None)
-    if run_id:
-        return [ManifestReader.get_run(runs_dir, run_id)]
-
-    kwargs: Dict[str, Any] = {}
-    if getattr(cli_args, "filter_set", None):
-        kwargs["set_name"] = cli_args.filter_set
-    if getattr(cli_args, "filter_tier", None):
-        kwargs["tier"] = cli_args.filter_tier
-    if getattr(cli_args, "filter_arch", None):
-        kwargs["arch"] = cli_args.filter_arch
-    if getattr(cli_args, "filter_tag", None):
-        kwargs["tag"] = cli_args.filter_tag
-    if since_str:
-        dt = parse_date_arg(since_str)
-        kwargs["since"] = dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
-    if until_str:
-        dt = parse_date_arg(until_str)
-        dt = dt.replace(hour=23, minute=59, second=59)
-        kwargs["until"] = dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
-
-    summaries = ManifestReader.find_runs(runs_dir, **kwargs)
-    return [ManifestReader.load(Path(summary["path"])) for summary in summaries]
 
 
 def _cache_one_run(

--- a/src/enge/utils/manifest_resolution.py
+++ b/src/enge/utils/manifest_resolution.py
@@ -1,0 +1,94 @@
+"""Shared invocation -> manifest(s) resolution.
+
+Independently resolves which manifest(s) a CLI invocation is backed by,
+given its parsed CLI args and manifest paths (via `AppContext`). Mirrors
+`utils/task_resolver.py`'s precedence (file > input >
+tags/date-only-without-manifest-filters -> legacy archive > no-args ->
+latest manifest > --run / filter selectors -> manifest store) closely
+enough to agree with it on manifest-backed vs. raw-input, but is not
+imported from it: `task_resolver` hands back a flat task_id list tuned
+for the xunit fetch layer, not the full manifest objects (and
+run_id-per-task attribution across N matched runs) this resolver's
+consumers need.
+
+Consumers: `report/results_cache.py` (`cache_report_results`'s
+manifest-backed gap-fill); the planned `enge compare` subcommand. A
+future unification of this resolver with `task_resolver` is a separate,
+maintainer-approved concern.
+"""
+
+from datetime import timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List
+
+from enge.utils import parse_date_arg
+from enge.utils.manifest import ManifestReader
+
+if TYPE_CHECKING:
+    from enge.utils.app_context import AppContext
+
+
+def resolve_manifests_for_invocation(ctx: "AppContext") -> List[Dict[str, Any]]:
+    """Independently resolve which manifest(s) this report invocation is
+    backed by. Mirrors utils/task_resolver.py's precedence (file > input >
+    tags/date-only-without-manifest-filters -> legacy archive > no-args ->
+    latest manifest > --run / filter selectors -> manifest store) closely
+    enough to agree with it on manifest-backed vs. raw-input, but is not
+    imported from it: task_resolver hands back a flat task_id list tuned
+    for the xunit fetch layer, not the full manifest objects (and
+    run_id-per-task attribution across N matched runs) this module needs.
+
+    Returns [] for raw-input invocations -- the caller no-ops in that
+    case."""
+    cli_args = ctx.cli_args
+    runs_dir = Path(ctx.manifest_runs_dir)
+
+    if getattr(cli_args, "file", None):
+        return []
+    if getattr(cli_args, "input", None):
+        return []
+
+    since_str = getattr(cli_args, "since", None)
+    until_str = getattr(cli_args, "until", None)
+    has_tags = bool(getattr(cli_args, "get_tag", None))
+    has_date_filter = bool(since_str or until_str)
+    has_manifest_filters = any(
+        getattr(cli_args, attr, None)
+        for attr in ("filter_set", "filter_tier", "filter_arch", "filter_tag", "run")
+    )
+
+    if (has_tags or has_date_filter) and not has_manifest_filters:
+        # Legacy archive path (--get-tag, or bare --since/--until with no
+        # manifest filters) -- no resolvable run_id.
+        return []
+
+    if not any((has_tags, has_date_filter, has_manifest_filters)):
+        # No selector at all: the latest manifest, if one exists. (If not,
+        # task_resolver falls back to the legacy latest-jobs file, which
+        # is also not manifest-backed -- nothing to cache either way.)
+        manifest_data = ManifestReader.load_latest(Path(ctx.manifest_latest))
+        return [manifest_data] if manifest_data else []
+
+    run_id = getattr(cli_args, "run", None)
+    if run_id:
+        return [ManifestReader.get_run(runs_dir, run_id)]
+
+    kwargs: Dict[str, Any] = {}
+    if getattr(cli_args, "filter_set", None):
+        kwargs["set_name"] = cli_args.filter_set
+    if getattr(cli_args, "filter_tier", None):
+        kwargs["tier"] = cli_args.filter_tier
+    if getattr(cli_args, "filter_arch", None):
+        kwargs["arch"] = cli_args.filter_arch
+    if getattr(cli_args, "filter_tag", None):
+        kwargs["tag"] = cli_args.filter_tag
+    if since_str:
+        dt = parse_date_arg(since_str)
+        kwargs["since"] = dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+    if until_str:
+        dt = parse_date_arg(until_str)
+        dt = dt.replace(hour=23, minute=59, second=59)
+        kwargs["until"] = dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+    summaries = ManifestReader.find_runs(runs_dir, **kwargs)
+    return [ManifestReader.load(Path(summary["path"])) for summary in summaries]


### PR DESCRIPTION
_resolve_manifests_for_report in report/results_cache.py mirrors task_resolver's selector precedence but returns full manifest objects instead of a flat task_id list. Promote it to a shared, public resolve_manifests_for_invocation() in utils/manifest_resolution.py so the upcoming `enge compare` subcommand can reuse it instead of reimplementing selector precedence a third time. results_cache.py now imports it as _resolve_manifests_for_report (aliased on import) so its call site and the cache_report_results docstring are unchanged.

Behavior-preserving: moved function body is AST-identical modulo the qualified name. No tests changed (none imported the private symbol directly). CLAUDE.md repo map and results.json write-policy section updated to name the new module.